### PR TITLE
bugfix: hand signal needed when review fails

### DIFF
--- a/.github/workflows/chatter.yaml
+++ b/.github/workflows/chatter.yaml
@@ -96,6 +96,6 @@ jobs:
           if (( RANDOM % 2 )); then
             gh issue comment "$ISSUE_NUMBER" --body "lgtm 👍"
           else
-            gh issue comment "$ISSUE_NUMBER" --body "bad, do not"
+            gh issue comment "$ISSUE_NUMBER" --body "bad, do not 🖕"
           fi
           


### PR DESCRIPTION
Without this someone might do instead of not do