### PR TITLE
Add GitHub Pages website with deterministic 4D banana

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,41 @@
+name: Deploy website
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - docs/**
+      - .github/workflows/pages.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload static site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@
 
 High performance, high velocity.
 
+## Website
+
+AgentPipe now includes a static website ready for GitHub Pages in [`docs/`](docs/).
+It contains:
+
+- a concise product description for contributors and customers
+- a download call-to-action that points to the repository archive
+- a deterministic client-side JavaScript canvas rendering of a projected 4D banana
+
+Run `npm run check:site` to validate that the required website files are present.
 
 ## Design
 

--- a/docs/assets/banana4d.js
+++ b/docs/assets/banana4d.js
@@ -1,0 +1,194 @@
+const canvas = document.querySelector("#banana-canvas");
+const context = canvas.getContext("2d");
+const statusNode = document.querySelector("#render-status");
+
+const SEED = 271828;
+const DPR_LIMIT = 2;
+const POINT_COUNT_U = 72;
+const POINT_COUNT_V = 18;
+
+let width = 0;
+let height = 0;
+let pointerX = 0;
+let pointerY = 0;
+let pointerActive = false;
+
+function seededNoise(index) {
+  const value = Math.sin(index * 12.9898 + SEED * 78.233) * 43758.5453;
+  return value - Math.floor(value);
+}
+
+function bananaPoint(uIndex, vIndex) {
+  const u = (uIndex / (POINT_COUNT_U - 1)) * Math.PI * 1.04;
+  const v = (vIndex / POINT_COUNT_V) * Math.PI * 2;
+  const taper = Math.sin(u);
+  const radius = 0.34 * taper + 0.045;
+  const arc = u - Math.PI / 2;
+  const bend = 1.52;
+  const surfaceNoise = (seededNoise(uIndex * 97 + vIndex * 31) - 0.5) * 0.035;
+
+  const x = Math.cos(arc) * bend + Math.cos(v) * (radius + surfaceNoise);
+  const y = Math.sin(v) * radius * 0.78 + Math.sin(u * 2.2) * 0.05;
+  const z = Math.sin(arc) * 0.68 + Math.cos(v) * radius * 0.42;
+  const w = Math.sin(u * 2.0 + v * 0.7) * 0.52 + Math.cos(u * 1.3) * 0.18;
+
+  return { x, y, z, w, u, v };
+}
+
+const bananaCloud = [];
+for (let u = 0; u < POINT_COUNT_U; u += 1) {
+  for (let v = 0; v < POINT_COUNT_V; v += 1) {
+    bananaCloud.push(bananaPoint(u, v));
+  }
+}
+
+function rotate2d(a, b, angle) {
+  const c = Math.cos(angle);
+  const s = Math.sin(angle);
+  return [a * c - b * s, a * s + b * c];
+}
+
+function rotate4d(point, time) {
+  const pointerTiltX = pointerActive ? pointerX * 0.7 : 0;
+  const pointerTiltY = pointerActive ? pointerY * 0.55 : 0;
+  let { x, y, z, w } = point;
+
+  [x, w] = rotate2d(x, w, time * 0.41 + pointerTiltX);
+  [y, z] = rotate2d(y, z, time * 0.28 + pointerTiltY);
+  [x, z] = rotate2d(x, z, -0.46 + time * 0.18);
+  [y, w] = rotate2d(y, w, 0.22 + time * 0.22);
+
+  return { x, y, z, w };
+}
+
+function project4Dto2D(point) {
+  const wPerspective = 2.7 / (2.7 - point.w * 0.46);
+  const zPerspective = 3.8 / (3.8 - point.z * 0.36);
+  const scale = Math.min(width, height) * 0.275 * wPerspective * zPerspective;
+
+  return {
+    x: width * 0.5 + point.x * scale,
+    y: height * 0.54 + point.y * scale,
+    depth: point.z + point.w * 0.34,
+    scale: wPerspective * zPerspective,
+    w: point.w,
+  };
+}
+
+function resize() {
+  const rect = canvas.getBoundingClientRect();
+  const dpr = Math.min(window.devicePixelRatio || 1, DPR_LIMIT);
+  width = Math.max(320, Math.floor(rect.width));
+  height = Math.max(320, Math.floor(rect.height));
+  canvas.width = Math.floor(width * dpr);
+  canvas.height = Math.floor(height * dpr);
+  context.setTransform(dpr, 0, 0, dpr, 0, 0);
+}
+
+function drawStem(x, y, rotation, scale) {
+  context.save();
+  context.translate(x, y);
+  context.rotate(rotation);
+  context.scale(scale, scale);
+  const stemGradient = context.createLinearGradient(-24, -12, 26, 20);
+  stemGradient.addColorStop(0, "#3b2c16");
+  stemGradient.addColorStop(0.55, "#8a6b22");
+  stemGradient.addColorStop(1, "#cf9f2d");
+  context.fillStyle = stemGradient;
+  context.beginPath();
+  context.moveTo(-34, -8);
+  context.bezierCurveTo(-18, -30, 19, -25, 32, -4);
+  context.bezierCurveTo(20, 11, -14, 15, -34, -8);
+  context.fill();
+  context.restore();
+}
+
+function renderBackground(time) {
+  const sky = context.createLinearGradient(0, 0, width, height);
+  sky.addColorStop(0, "#fff7bc");
+  sky.addColorStop(0.4, "#f6d44f");
+  sky.addColorStop(0.72, "#4f7c58");
+  sky.addColorStop(1, "#16130a");
+  context.fillStyle = sky;
+  context.fillRect(0, 0, width, height);
+
+  context.save();
+  context.globalAlpha = 0.24;
+  context.strokeStyle = "#fff8c8";
+  context.lineWidth = 1;
+  for (let ring = 0; ring < 7; ring += 1) {
+    context.beginPath();
+    const radius = 54 + ring * 38 + Math.sin(time + ring) * 4;
+    context.ellipse(width * 0.5, height * 0.54, radius * 1.7, radius * 0.72, -0.18, 0, Math.PI * 2);
+    context.stroke();
+  }
+  context.restore();
+}
+
+function renderBanana(timeMs) {
+  const time = timeMs * 0.001;
+  renderBackground(time);
+
+  const projected = bananaCloud
+    .map((point) => {
+      const rotated = rotate4d(point, time);
+      return {
+        source: point,
+        projected: project4Dto2D(rotated),
+      };
+    })
+    .sort((a, b) => a.projected.depth - b.projected.depth);
+
+  context.save();
+  context.shadowColor = "rgba(52, 35, 0, 0.3)";
+  context.shadowBlur = 18;
+  context.shadowOffsetY = 12;
+
+  for (const item of projected) {
+    const { source, projected: dot } = item;
+    const light = Math.max(0, Math.min(1, 0.58 + dot.depth * 0.2 + Math.cos(source.v) * 0.18));
+    const alpha = Math.max(0.48, Math.min(0.95, 0.68 + dot.scale * 0.12));
+    const radius = Math.max(1.15, 2.75 * dot.scale + Math.sin(source.u * 3) * 0.45);
+    const greenEdge = Math.max(0, Math.sin(source.u * Math.PI));
+    const hue = 43 + greenEdge * 9 + dot.w * 4;
+    const saturation = 85 - Math.abs(dot.w) * 9;
+    const luminance = 44 + light * 26;
+
+    context.fillStyle = `hsla(${hue}, ${saturation}%, ${luminance}%, ${alpha})`;
+    context.beginPath();
+    context.arc(dot.x, dot.y, radius, 0, Math.PI * 2);
+    context.fill();
+  }
+
+  context.restore();
+
+  const left = projected[0]?.projected;
+  const right = projected[projected.length - 1]?.projected;
+  if (left && right) {
+    drawStem(width * 0.27, height * 0.61, -0.58 + Math.sin(time) * 0.08, 0.72);
+    drawStem(width * 0.73, height * 0.41, 2.72 + Math.cos(time) * 0.08, 0.62);
+  }
+
+  if (statusNode) {
+    statusNode.textContent = `seed ${SEED} · ${bananaCloud.length} deterministic 4D samples`;
+  }
+
+  requestAnimationFrame(renderBanana);
+}
+
+function setPointer(event) {
+  const rect = canvas.getBoundingClientRect();
+  pointerX = ((event.clientX - rect.left) / rect.width - 0.5) * 2;
+  pointerY = ((event.clientY - rect.top) / rect.height - 0.5) * 2;
+  pointerActive = true;
+}
+
+canvas.addEventListener("pointermove", setPointer);
+canvas.addEventListener("pointerenter", setPointer);
+canvas.addEventListener("pointerleave", () => {
+  pointerActive = false;
+});
+
+window.addEventListener("resize", resize);
+resize();
+requestAnimationFrame(renderBanana);

--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -1,0 +1,368 @@
+:root {
+  color-scheme: light;
+  --yellow-100: #fff8d6;
+  --yellow-300: #ffe478;
+  --yellow-500: #f6c915;
+  --yellow-700: #a77300;
+  --green-600: #28684b;
+  --ink: #16130a;
+  --muted: #665c42;
+  --paper: #fffdf4;
+  --line: rgba(69, 49, 8, 0.16);
+  --shadow: 0 24px 70px rgba(87, 61, 0, 0.18);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  line-height: 1.5;
+  color: var(--ink);
+  background:
+    linear-gradient(180deg, rgba(255, 248, 214, 0.94), rgba(255, 253, 244, 1) 38%),
+    var(--paper);
+}
+
+a {
+  color: inherit;
+}
+
+.skip-link {
+  position: absolute;
+  left: 1rem;
+  top: -4rem;
+  z-index: 4;
+  padding: 0.75rem 1rem;
+  background: var(--ink);
+  color: white;
+}
+
+.skip-link:focus {
+  top: 1rem;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.9rem clamp(1rem, 4vw, 4rem);
+  background: rgba(255, 253, 244, 0.86);
+  border-bottom: 1px solid var(--line);
+  backdrop-filter: blur(18px);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-weight: 800;
+  letter-spacing: 0;
+}
+
+.brand-mark {
+  display: grid;
+  width: 2rem;
+  height: 2rem;
+  place-items: center;
+  border-radius: 50%;
+  color: #291d00;
+  background: radial-gradient(circle at 38% 30%, #fffbd2, var(--yellow-500) 68%);
+  box-shadow: inset 0 0 0 1px rgba(92, 66, 0, 0.18);
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: clamp(0.8rem, 2vw, 1.6rem);
+  color: var(--muted);
+  font-size: 0.94rem;
+  font-weight: 650;
+}
+
+.nav-links a {
+  text-decoration: none;
+}
+
+.nav-links a:hover {
+  color: var(--ink);
+}
+
+.hero {
+  min-height: calc(100svh - 4rem);
+  display: grid;
+  grid-template-columns: minmax(0, 0.82fr) minmax(22rem, 1fr);
+  align-items: stretch;
+  gap: clamp(1.4rem, 5vw, 4rem);
+  padding: clamp(2rem, 6vw, 5rem) clamp(1rem, 4vw, 4rem) 2rem;
+}
+
+.hero-copy {
+  align-self: center;
+  max-width: 43rem;
+}
+
+.eyebrow {
+  margin: 0 0 1rem;
+  color: var(--green-600);
+  font-size: 0.78rem;
+  font-weight: 850;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  overflow-wrap: anywhere;
+}
+
+h1 {
+  margin: 0;
+  max-width: 12ch;
+  font-size: clamp(3.1rem, 8vw, 7.2rem);
+  line-height: 0.9;
+  letter-spacing: 0;
+}
+
+.lead {
+  max-width: 39rem;
+  margin: 1.5rem 0 0;
+  color: #473d28;
+  font-size: clamp(1.08rem, 2vw, 1.34rem);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  margin-top: 2rem;
+}
+
+.button {
+  display: inline-flex;
+  min-height: 3rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  padding: 0.82rem 1.08rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--ink);
+  background: white;
+  font-weight: 800;
+  text-decoration: none;
+  box-shadow: 0 8px 24px rgba(109, 78, 0, 0.09);
+}
+
+.button.primary {
+  border-color: rgba(105, 75, 0, 0.2);
+  background: linear-gradient(180deg, #ffe87f, #f3bd09);
+}
+
+.button:hover {
+  transform: translateY(-1px);
+}
+
+.hero-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.8rem;
+  max-width: 42rem;
+  margin-top: 2.25rem;
+}
+
+.metric {
+  padding: 0 0 0 0.9rem;
+  border-left: 2px solid rgba(40, 104, 75, 0.35);
+}
+
+.metric strong {
+  display: block;
+  font-size: 1.05rem;
+}
+
+.metric span {
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.banana-stage {
+  position: relative;
+  min-height: min(71svh, 46rem);
+  align-self: stretch;
+  overflow: hidden;
+  border: 1px solid rgba(80, 58, 0, 0.18);
+  border-radius: 8px;
+  background: #f7d63d;
+  box-shadow: var(--shadow);
+}
+
+#banana-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  min-height: 25rem;
+  cursor: grab;
+}
+
+#banana-canvas:active {
+  cursor: grabbing;
+}
+
+.canvas-caption {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.7rem;
+  padding: 0.72rem 0.84rem;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: 8px;
+  color: #fff8d6;
+  background: rgba(18, 15, 7, 0.72);
+  font-size: 0.82rem;
+  backdrop-filter: blur(12px);
+}
+
+.section {
+  padding: clamp(3rem, 7vw, 6rem) clamp(1rem, 4vw, 4rem);
+}
+
+.section-inner {
+  width: min(72rem, 100%);
+  margin: 0 auto;
+}
+
+.section h2 {
+  max-width: 18ch;
+  margin: 0 0 1rem;
+  font-size: clamp(2rem, 5vw, 4rem);
+  line-height: 0.98;
+  letter-spacing: 0;
+}
+
+.section-copy {
+  max-width: 48rem;
+  margin: 0;
+  color: #4f4632;
+  font-size: 1.08rem;
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.feature-card {
+  min-height: 13rem;
+  padding: 1.2rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.68);
+}
+
+.feature-card h3 {
+  margin: 0 0 0.8rem;
+  font-size: 1.1rem;
+}
+
+.feature-card p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.download-band {
+  margin-top: 2.4rem;
+  padding: clamp(1.2rem, 3vw, 1.8rem);
+  border: 1px solid rgba(40, 104, 75, 0.18);
+  border-radius: 8px;
+  background: linear-gradient(110deg, #fff4ad, #e4f0c7 55%, #f9ffe9);
+}
+
+.download-band p {
+  margin: 0.5rem 0 0;
+  color: #475135;
+}
+
+.site-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.5rem clamp(1rem, 4vw, 4rem);
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 900px) {
+  .hero {
+    grid-template-columns: 1fr;
+    min-height: auto;
+  }
+
+  h1 {
+    max-width: 10ch;
+  }
+
+  .banana-stage {
+    min-height: 33rem;
+  }
+
+  .feature-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 620px) {
+  .site-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .nav-links {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .hero {
+    padding-top: 1.5rem;
+  }
+
+  .hero-metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .actions {
+    flex-direction: column;
+  }
+
+  .button {
+    width: 100%;
+  }
+
+  .banana-stage {
+    min-height: 27rem;
+  }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,129 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="AgentPipe is a high-velocity open source project with a deterministic client-side 4D banana rendering."
+    />
+    <title>AgentPipe</title>
+    <link rel="stylesheet" href="./assets/site.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" aria-label="Primary">
+      <a class="brand" href="#top" aria-label="AgentPipe home">
+        <span class="brand-mark" aria-hidden="true">A</span>
+        <span>AgentPipe</span>
+      </a>
+      <nav class="nav-links" aria-label="Site">
+        <a href="#about">About</a>
+        <a href="#download">Download</a>
+        <a href="https://github.com/dwebagents/AgentPipe">GitHub</a>
+      </nav>
+    </header>
+
+    <main id="main">
+      <section id="top" class="hero" aria-labelledby="hero-title">
+        <div class="hero-copy">
+          <p class="eyebrow">Open source infrastructure, maximum urgency</p>
+          <h1 id="hero-title">AgentPipe</h1>
+          <p class="lead">
+            AgentPipe turns high-velocity data flow experiments into a shared
+            open source workspace for contributors, customers, and anyone who
+            needs important code to move with confidence.
+          </p>
+          <div class="actions" aria-label="Primary actions">
+            <a
+              class="button primary"
+              href="https://github.com/dwebagents/AgentPipe/archive/refs/heads/main.zip"
+            >
+              Download project
+            </a>
+            <a class="button" href="https://github.com/dwebagents/AgentPipe">
+              View repository
+            </a>
+          </div>
+          <div class="hero-metrics" aria-label="Project highlights">
+            <div class="metric">
+              <strong>Static</strong>
+              <span>ready for GitHub Pages</span>
+            </div>
+            <div class="metric">
+              <strong>Client-side</strong>
+              <span>deterministic 4D rendering</span>
+            </div>
+            <div class="metric">
+              <strong>Open</strong>
+              <span>built for contributors</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="banana-stage" aria-label="Deterministic 4D banana graphic">
+          <canvas id="banana-canvas" width="960" height="960">
+            A deterministic JavaScript rendering of a projected 4D banana.
+          </canvas>
+          <div class="canvas-caption">
+            <span>Projected 4D banana</span>
+            <span id="render-status">deterministic render initializing</span>
+          </div>
+        </div>
+      </section>
+
+      <section id="about" class="section" aria-labelledby="about-title">
+        <div class="section-inner">
+          <h2 id="about-title">Important code deserves a front door.</h2>
+          <p class="section-copy">
+            AgentPipe presents a playful but practical home for the project:
+            what it is, where to download it, and why contributors should care.
+            The page is static, fast to host, and designed to work directly from
+            GitHub Pages without server-side dependencies.
+          </p>
+
+          <div class="feature-grid">
+            <article class="feature-card">
+              <h3>Clear project story</h3>
+              <p>
+                The site explains AgentPipe as a high-performance experimental
+                codebase for real-time indexing, data flow, and contributor-led
+                improvement.
+              </p>
+            </article>
+            <article class="feature-card">
+              <h3>Download path</h3>
+              <p>
+                A direct archive link lets visitors download the latest main
+                branch while still keeping the GitHub repository one click away.
+              </p>
+            </article>
+            <article class="feature-card">
+              <h3>Deterministic graphic</h3>
+              <p>
+                The banana canvas uses seeded math and 4D projection routines so
+                the generated shape is reproducible in the browser.
+              </p>
+            </article>
+          </div>
+
+          <div id="download" class="download-band">
+            <h2>Ready for Pages.</h2>
+            <p>
+              Serve the <code>docs/</code> directory with GitHub Pages or use the
+              included workflow to publish the static site after merge.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <span>AgentPipe website for GitHub Pages</span>
+      <a href="https://github.com/dwebagents/AgentPipe/issues/112">Bounty #112</a>
+    </footer>
+
+    <script src="./assets/banana4d.js" defer></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "check:site": "node scripts/check-site.mjs"
+  },
   "dependencies": {
     "@11ty/eleventy": "^3.1.6"
   }

--- a/scripts/check-site.mjs
+++ b/scripts/check-site.mjs
@@ -1,0 +1,53 @@
+import { readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const root = new URL("..", import.meta.url).pathname;
+
+const requiredFiles = [
+  "docs/index.html",
+  "docs/assets/site.css",
+  "docs/assets/banana4d.js",
+  ".github/workflows/pages.yml",
+];
+
+for (const file of requiredFiles) {
+  const fullPath = join(root, file);
+  const stats = statSync(fullPath);
+  if (!stats.isFile() || stats.size === 0) {
+    throw new Error(`${file} must exist and be non-empty`);
+  }
+}
+
+const html = readFileSync(join(root, "docs/index.html"), "utf8");
+const css = readFileSync(join(root, "docs/assets/site.css"), "utf8");
+const js = readFileSync(join(root, "docs/assets/banana4d.js"), "utf8");
+
+const requiredHtml = [
+  "AgentPipe",
+  "Download project",
+  "banana-canvas",
+  "Projected 4D banana",
+  "https://github.com/dwebagents/AgentPipe/archive/refs/heads/main.zip",
+];
+
+for (const token of requiredHtml) {
+  if (!html.includes(token)) {
+    throw new Error(`docs/index.html is missing ${token}`);
+  }
+}
+
+const requiredJs = ["SEED", "bananaPoint", "rotate4d", "project4Dto2D"];
+for (const token of requiredJs) {
+  if (!js.includes(token)) {
+    throw new Error(`banana4d.js is missing ${token}`);
+  }
+}
+
+const requiredCss = ["--yellow-500", ".banana-stage", "@media"];
+for (const token of requiredCss) {
+  if (!css.includes(token)) {
+    throw new Error(`site.css is missing ${token}`);
+  }
+}
+
+console.log("AgentPipe website checks passed.");


### PR DESCRIPTION
## Summary
- Add a static GitHub Pages website in `docs/`.
- Include project description and download button.
- Add a deterministic client-side JavaScript 4D banana canvas graphic.
- Add a Pages deployment workflow and site validation script.

## Tests
- npm run check:site

Closes #112