### PR TITLE
Add 8D banana audio and chess lab

### DIFF
--- a/docs/banana8d.js
+++ b/docs/banana8d.js
@@ -1,0 +1,216 @@
+(() => {
+  const audioToggle = document.getElementById("audio8d-toggle");
+  const audioReadout = document.getElementById("audio8d-readout");
+  const hrtfInput = document.getElementById("hrtf-input");
+  const board = document.getElementById("chess8d-board");
+  const chessReadout = document.getElementById("chess8d-readout");
+  const prevButton = document.getElementById("chess8d-prev");
+  const nextButton = document.getElementById("chess8d-next");
+
+  const TAU = Math.PI * 2;
+  const BOARD_SIZE = 8;
+  const PLAYER_COUNT = 8;
+
+  function clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
+  }
+
+  function parseVector(value) {
+    const parsed = String(value)
+      .split(/[,\s]+/)
+      .map((part) => Number(part.trim()))
+      .filter((part) => Number.isFinite(part))
+      .slice(0, 8);
+
+    while (parsed.length < 8) {
+      parsed.push(0);
+    }
+
+    return parsed.map((part) => clamp(part, -1.5, 1.5));
+  }
+
+  function rotate8d(vector, time) {
+    const next = vector.slice(0, 8);
+    for (let axis = 0; axis < 8; axis += 2) {
+      const angle = time * (0.17 + axis * 0.025) + axis * 0.19;
+      const a = next[axis];
+      const b = next[axis + 1];
+      next[axis] = a * Math.cos(angle) - b * Math.sin(angle);
+      next[axis + 1] = a * Math.sin(angle) + b * Math.cos(angle);
+    }
+    return next;
+  }
+
+  function project8d(vector) {
+    const weightsX = [1, 0.72, -0.48, 0.31, -0.2, 0.14, -0.1, 0.07];
+    const weightsY = [0.18, -0.42, 0.96, 0.54, -0.36, 0.22, 0.11, -0.08];
+    const x = vector.reduce((total, value, index) => total + value * weightsX[index], 0);
+    const y = vector.reduce((total, value, index) => total + value * weightsY[index], 0);
+    const depth = vector.reduce((total, value, index) => total + value * (index + 1), 0) / 18;
+    return { x: clamp(x / 2.4, -1, 1), y: clamp(y / 2.4, -1, 1), depth };
+  }
+
+  function bananaMotif(time, hrtfVector) {
+    const base = [1, 0.75, 0.45, 0.18, -0.18, -0.45, -0.75, -1];
+    return base.map((value, index) => {
+      const wobble = Math.sin(time * (0.8 + index * 0.07) + index) * 0.35;
+      return value + wobble + hrtfVector[index] * 0.22;
+    });
+  }
+
+  let audioContext = null;
+  let oscillator = null;
+  let gain = null;
+  let panner = null;
+  let audioFrame = 0;
+  let playing = false;
+
+  function stopAudio() {
+    playing = false;
+    if (oscillator) {
+      oscillator.stop();
+      oscillator.disconnect();
+      oscillator = null;
+    }
+    if (gain) {
+      gain.disconnect();
+      gain = null;
+    }
+    if (panner) {
+      panner.disconnect();
+      panner = null;
+    }
+    if (audioToggle) {
+      audioToggle.textContent = "Start 8D banana audio";
+    }
+    if (audioReadout) {
+      audioReadout.textContent = "audio idle";
+    }
+    cancelAnimationFrame(audioFrame);
+  }
+
+  function updateAudio() {
+    if (!playing || !audioContext || !gain || !panner) {
+      return;
+    }
+    const time = audioContext.currentTime;
+    const hrtfVector = parseVector(hrtfInput?.value || "");
+    const projected = project8d(rotate8d(bananaMotif(time, hrtfVector), time));
+    panner.pan.setTargetAtTime(projected.x, time, 0.025);
+    gain.gain.setTargetAtTime(0.18 + Math.max(0, projected.depth) * 0.04, time, 0.03);
+    if (oscillator) {
+      oscillator.frequency.setTargetAtTime(220 + (projected.y + 1) * 110, time, 0.04);
+    }
+    if (audioReadout) {
+      audioReadout.textContent = `pan ${projected.x.toFixed(2)} · pitch ${(220 + (projected.y + 1) * 110).toFixed(0)} Hz`;
+    }
+    audioFrame = requestAnimationFrame(updateAudio);
+  }
+
+  async function startAudio() {
+    audioContext = audioContext || new AudioContext();
+    await audioContext.resume();
+    oscillator = audioContext.createOscillator();
+    gain = audioContext.createGain();
+    panner = audioContext.createStereoPanner();
+    oscillator.type = "triangle";
+    gain.gain.value = 0.16;
+    oscillator.connect(gain);
+    gain.connect(panner);
+    panner.connect(audioContext.destination);
+    oscillator.start();
+    playing = true;
+    if (audioToggle) {
+      audioToggle.textContent = "Stop 8D banana audio";
+    }
+    updateAudio();
+  }
+
+  audioToggle?.addEventListener("click", async () => {
+    if (playing) {
+      stopAudio();
+      return;
+    }
+    try {
+      await startAudio();
+    } catch (error) {
+      if (audioReadout) {
+        audioReadout.textContent = `audio unavailable: ${error.message}`;
+      }
+    }
+  });
+
+  const pieces = [
+    { player: 1, piece: "K", vector: [0, 0, 0, 0, 0, 0, 0, 0] },
+    { player: 2, piece: "Q", vector: [7, 7, 7, 7, 7, 7, 7, 7] },
+    { player: 3, piece: "R", vector: [0, 7, 0, 7, 0, 7, 0, 7] },
+    { player: 4, piece: "B", vector: [7, 0, 7, 0, 7, 0, 7, 0] },
+    { player: 5, piece: "N", vector: [2, 5, 3, 6, 1, 4, 0, 7] },
+    { player: 6, piece: "P", vector: [5, 2, 6, 3, 4, 1, 7, 0] },
+    { player: 7, piece: "Ω", vector: [1, 6, 2, 5, 3, 4, 7, 0] },
+    { player: 8, piece: "♙", vector: [6, 1, 5, 2, 4, 3, 0, 7] },
+  ];
+
+  function normalizeBoardVector(vector) {
+    return vector.map((value) => (value / (BOARD_SIZE - 1)) * 2 - 1);
+  }
+
+  function cellIndexForVector(vector) {
+    const projected = project8d(normalizeBoardVector(vector));
+    const x = clamp(Math.round(((projected.x + 1) / 2) * (BOARD_SIZE - 1)), 0, BOARD_SIZE - 1);
+    const y = clamp(Math.round(((projected.y + 1) / 2) * (BOARD_SIZE - 1)), 0, BOARD_SIZE - 1);
+    return y * BOARD_SIZE + x;
+  }
+
+  function vectorNotation(vector) {
+    return vector.map((value, index) => `${String.fromCharCode(97 + index)}${value + 1}`).join(" ");
+  }
+
+  let activeMove = 0;
+
+  function renderChess() {
+    if (!board) {
+      return;
+    }
+    board.innerHTML = "";
+    const cells = Array.from({ length: BOARD_SIZE * BOARD_SIZE }, (_, index) => {
+      const cell = document.createElement("span");
+      cell.className = "chess8d-cell";
+      cell.textContent = index % 9 === 0 ? "8D" : "";
+      board.appendChild(cell);
+      return cell;
+    });
+
+    pieces.forEach((piece, index) => {
+      const cell = cells[cellIndexForVector(piece.vector)];
+      cell.classList.add(index === activeMove ? "active" : "player");
+      cell.textContent = `${piece.piece}${piece.player}`;
+      cell.title = `Player ${piece.player}: ${vectorNotation(piece.vector)}`;
+    });
+
+    const active = pieces[activeMove];
+    if (chessReadout) {
+      chessReadout.textContent = `vector ${activeMove + 1} of ${pieces.length}: P${active.player} ${active.piece} · ${vectorNotation(active.vector)}`;
+    }
+  }
+
+  prevButton?.addEventListener("click", () => {
+    activeMove = (activeMove + pieces.length - 1) % pieces.length;
+    renderChess();
+  });
+
+  nextButton?.addEventListener("click", () => {
+    activeMove = (activeMove + 1) % pieces.length;
+    renderChess();
+  });
+
+  renderChess();
+
+  window.AgentPipe8D = {
+    parseVector,
+    rotate8d,
+    project8d,
+    cellIndexForVector,
+    pieces,
+  };
+})();

--- a/docs/banana8d.js
+++ b/docs/banana8d.js
@@ -3,6 +3,7 @@
   const audioReadout = document.getElementById("audio8d-readout");
   const hrtfInput = document.getElementById("hrtf-input");
   const board = document.getElementById("chess8d-board");
+  const roster = document.getElementById("chess8d-roster");
   const chessReadout = document.getElementById("chess8d-readout");
   const prevButton = document.getElementById("chess8d-prev");
   const nextButton = document.getElementById("chess8d-next");
@@ -12,6 +13,7 @@
   const PLAYER_COUNT = 8;
   const PIECES_PER_PLAYER = 16;
   const TOTAL_CHESS_PIECES = PLAYER_COUNT * PIECES_PER_PLAYER;
+  const CHESS_BACK_RANK = ["R", "N", "B", "Q", "K", "B", "N", "R"];
   const MUSIC_BPM = 96;
 
   function clamp(value, min, max) {
@@ -141,7 +143,7 @@
       audioToggle.textContent = "Start 8D banana audio";
     }
     if (audioReadout) {
-      audioReadout.textContent = "audio idle";
+      audioReadout.textContent = "music playback idle";
     }
     cancelAnimationFrame(audioFrame);
   }
@@ -157,7 +159,7 @@
     gain.gain.setTargetAtTime(0.18 + Math.max(0, projected.depth) * 0.04, time, 0.03);
     musicSource.playbackRate.setTargetAtTime(0.94 + (projected.y + 1) * 0.045, time, 0.04);
     if (audioReadout) {
-      audioReadout.textContent = `playing banana music · pan ${projected.x.toFixed(2)} · rate ${musicSource.playbackRate.value.toFixed(2)}x`;
+      audioReadout.textContent = `playing generated music buffer · pan ${projected.x.toFixed(2)} · rate ${musicSource.playbackRate.value.toFixed(2)}x`;
     }
     audioFrame = requestAnimationFrame(updateAudio);
   }
@@ -198,35 +200,44 @@
   });
 
   function create8DChessPieces() {
-    const backRank = ["R", "N", "B", "Q", "K", "B", "N", "R"];
     const allPieces = [];
 
     for (let playerIndex = 0; playerIndex < PLAYER_COUNT; playerIndex += 1) {
       const player = playerIndex + 1;
-      const forwardAxis = playerIndex;
-      const fileAxis = (playerIndex + 1) % 8;
       const homeRank = playerIndex % 2 === 0 ? 0 : BOARD_SIZE - 1;
       const pawnRank = playerIndex % 2 === 0 ? 1 : BOARD_SIZE - 2;
 
-      backRank.forEach((piece, file) => {
-        const vector = Array.from({ length: 8 }, (_, axis) => playerIndex);
-        vector[forwardAxis] = homeRank;
-        vector[fileAxis] = file;
-        allPieces.push({ player, piece, vector });
+      CHESS_BACK_RANK.forEach((piece, file) => {
+        const vector = chessVector(playerIndex, homeRank, file, file);
+        allPieces.push({ player, piece, file: file + 1, vector });
       });
 
       for (let file = 0; file < BOARD_SIZE; file += 1) {
-        const vector = Array.from({ length: 8 }, (_, axis) => playerIndex);
-        vector[forwardAxis] = pawnRank;
-        vector[fileAxis] = file;
-        allPieces.push({ player, piece: "P", vector });
+        const vector = chessVector(playerIndex, pawnRank, file, file + CHESS_BACK_RANK.length);
+        allPieces.push({ player, piece: "P", file: file + 1, vector });
       }
     }
 
     return allPieces;
   }
 
+  function chessVector(playerIndex, rank, file, pieceOffset) {
+    const forwardAxis = playerIndex;
+    const fileAxis = (playerIndex + 1) % 8;
+    const pieceAxis = (playerIndex + 2) % 8;
+    const playerAxis = (playerIndex + 3) % 8;
+    const vector = Array.from({ length: 8 }, (_, axis) => (playerIndex + axis) % BOARD_SIZE);
+    vector[forwardAxis] = rank;
+    vector[fileAxis] = file;
+    vector[pieceAxis] = (pieceOffset + playerIndex) % BOARD_SIZE;
+    vector[playerAxis] = playerIndex;
+    return vector;
+  }
+
   const pieces = create8DChessPieces();
+  if (pieces.length !== TOTAL_CHESS_PIECES) {
+    throw new Error(`Expected ${TOTAL_CHESS_PIECES} 8D chess pieces, got ${pieces.length}`);
+  }
 
   function normalizeBoardVector(vector) {
     return vector.map((value) => (value / (BOARD_SIZE - 1)) * 2 - 1);
@@ -244,6 +255,25 @@
   }
 
   let activeMove = 0;
+
+  function renderChessRoster() {
+    if (!roster) {
+      return;
+    }
+    roster.innerHTML = "";
+    for (let player = 1; player <= PLAYER_COUNT; player += 1) {
+      const playerPieces = pieces.filter((piece) => piece.player === player);
+      const entry = document.createElement("div");
+      entry.className = "chess8d-roster-player";
+      entry.textContent = `P${player} (${playerPieces.length}/${PIECES_PER_PLAYER}): ${playerPieces
+        .map((piece) => `${piece.piece}${piece.file}`)
+        .join(" ")}`;
+      entry.title = playerPieces
+        .map((piece) => `Player ${piece.player} ${piece.piece}${piece.file}: ${vectorNotation(piece.vector)}`)
+        .join("\n");
+      roster.appendChild(entry);
+    }
+  }
 
   function renderChess() {
     if (!board) {
@@ -283,6 +313,7 @@
     if (chessReadout) {
       chessReadout.textContent = `vector ${activeMove + 1} of ${pieces.length}: P${active.player} ${active.piece} · ${vectorNotation(active.vector)}`;
     }
+    renderChessRoster();
   }
 
   prevButton?.addEventListener("click", () => {
@@ -304,6 +335,7 @@
     buildBananaMusicBuffer,
     create8DChessPieces,
     cellIndexForVector,
+    PIECES_PER_PLAYER,
     TOTAL_CHESS_PIECES,
     pieces,
   };

--- a/docs/banana8d.js
+++ b/docs/banana8d.js
@@ -10,6 +10,9 @@
   const TAU = Math.PI * 2;
   const BOARD_SIZE = 8;
   const PLAYER_COUNT = 8;
+  const PIECES_PER_PLAYER = 16;
+  const TOTAL_CHESS_PIECES = PLAYER_COUNT * PIECES_PER_PLAYER;
+  const MUSIC_BPM = 96;
 
   function clamp(value, min, max) {
     return Math.min(max, Math.max(min, value));
@@ -59,18 +62,72 @@
   }
 
   let audioContext = null;
-  let oscillator = null;
+  let musicSource = null;
+  let musicBuffer = null;
   let gain = null;
   let panner = null;
   let audioFrame = 0;
   let playing = false;
 
+  function midiToFrequency(note) {
+    return 440 * 2 ** ((note - 69) / 12);
+  }
+
+  function noteEnvelope(timeIntoNote, noteLength) {
+    const attack = Math.min(0.025, noteLength * 0.18);
+    const release = Math.min(0.12, noteLength * 0.28);
+    if (timeIntoNote < attack) {
+      return timeIntoNote / attack;
+    }
+    if (timeIntoNote > noteLength - release) {
+      return Math.max(0, (noteLength - timeIntoNote) / release);
+    }
+    return 0.86;
+  }
+
+  function buildBananaMusicBuffer(context) {
+    const sampleRate = context.sampleRate;
+    const duration = 12;
+    const frameCount = Math.floor(sampleRate * duration);
+    const buffer = context.createBuffer(2, frameCount, sampleRate);
+    const left = buffer.getChannelData(0);
+    const right = buffer.getChannelData(1);
+    const beatLength = 60 / MUSIC_BPM;
+    const melody = [64, 67, 71, 72, 71, 67, 64, 60, 62, 65, 69, 74, 72, 69, 65, 62];
+    const bass = [40, 40, 47, 47, 45, 45, 43, 43];
+    const chord = [52, 55, 59, 64];
+
+    for (let frame = 0; frame < frameCount; frame += 1) {
+      const time = frame / sampleRate;
+      const beat = Math.floor(time / beatLength);
+      const beatTime = time % beatLength;
+      const barPhase = (time % (beatLength * 8)) / (beatLength * 8);
+      const melodyFrequency = midiToFrequency(melody[beat % melody.length]);
+      const bassFrequency = midiToFrequency(bass[Math.floor(beat / 2) % bass.length]);
+      const chordFrequency = midiToFrequency(chord[(beat + Math.floor(time * 2)) % chord.length]);
+      const envelope = noteEnvelope(beatTime, beatLength);
+      const swing = 0.74 + Math.sin(barPhase * TAU) * 0.16;
+      const melodySample =
+        Math.sin(time * TAU * melodyFrequency) * 0.55 +
+        Math.sin(time * TAU * melodyFrequency * 2) * 0.14;
+      const chordSample = Math.sin(time * TAU * chordFrequency) * 0.18;
+      const bassSample = Math.sin(time * TAU * bassFrequency) * 0.28;
+      const tick = beatTime < 0.025 ? (1 - beatTime / 0.025) * 0.08 : 0;
+      const sample = Math.tanh((melodySample * envelope + chordSample + bassSample + tick) * 0.72);
+
+      left[frame] = sample * (0.78 - swing * 0.12);
+      right[frame] = sample * (0.62 + swing * 0.18);
+    }
+
+    return buffer;
+  }
+
   function stopAudio() {
     playing = false;
-    if (oscillator) {
-      oscillator.stop();
-      oscillator.disconnect();
-      oscillator = null;
+    if (musicSource) {
+      musicSource.stop();
+      musicSource.disconnect();
+      musicSource = null;
     }
     if (gain) {
       gain.disconnect();
@@ -90,7 +147,7 @@
   }
 
   function updateAudio() {
-    if (!playing || !audioContext || !gain || !panner) {
+    if (!playing || !audioContext || !gain || !panner || !musicSource) {
       return;
     }
     const time = audioContext.currentTime;
@@ -98,11 +155,9 @@
     const projected = project8d(rotate8d(bananaMotif(time, hrtfVector), time));
     panner.pan.setTargetAtTime(projected.x, time, 0.025);
     gain.gain.setTargetAtTime(0.18 + Math.max(0, projected.depth) * 0.04, time, 0.03);
-    if (oscillator) {
-      oscillator.frequency.setTargetAtTime(220 + (projected.y + 1) * 110, time, 0.04);
-    }
+    musicSource.playbackRate.setTargetAtTime(0.94 + (projected.y + 1) * 0.045, time, 0.04);
     if (audioReadout) {
-      audioReadout.textContent = `pan ${projected.x.toFixed(2)} · pitch ${(220 + (projected.y + 1) * 110).toFixed(0)} Hz`;
+      audioReadout.textContent = `playing banana music · pan ${projected.x.toFixed(2)} · rate ${musicSource.playbackRate.value.toFixed(2)}x`;
     }
     audioFrame = requestAnimationFrame(updateAudio);
   }
@@ -110,15 +165,17 @@
   async function startAudio() {
     audioContext = audioContext || new AudioContext();
     await audioContext.resume();
-    oscillator = audioContext.createOscillator();
+    musicBuffer = musicBuffer || buildBananaMusicBuffer(audioContext);
+    musicSource = audioContext.createBufferSource();
     gain = audioContext.createGain();
     panner = audioContext.createStereoPanner();
-    oscillator.type = "triangle";
+    musicSource.buffer = musicBuffer;
+    musicSource.loop = true;
     gain.gain.value = 0.16;
-    oscillator.connect(gain);
+    musicSource.connect(gain);
     gain.connect(panner);
     panner.connect(audioContext.destination);
-    oscillator.start();
+    musicSource.start();
     playing = true;
     if (audioToggle) {
       audioToggle.textContent = "Stop 8D banana audio";
@@ -140,16 +197,36 @@
     }
   });
 
-  const pieces = [
-    { player: 1, piece: "K", vector: [0, 0, 0, 0, 0, 0, 0, 0] },
-    { player: 2, piece: "Q", vector: [7, 7, 7, 7, 7, 7, 7, 7] },
-    { player: 3, piece: "R", vector: [0, 7, 0, 7, 0, 7, 0, 7] },
-    { player: 4, piece: "B", vector: [7, 0, 7, 0, 7, 0, 7, 0] },
-    { player: 5, piece: "N", vector: [2, 5, 3, 6, 1, 4, 0, 7] },
-    { player: 6, piece: "P", vector: [5, 2, 6, 3, 4, 1, 7, 0] },
-    { player: 7, piece: "Ω", vector: [1, 6, 2, 5, 3, 4, 7, 0] },
-    { player: 8, piece: "♙", vector: [6, 1, 5, 2, 4, 3, 0, 7] },
-  ];
+  function create8DChessPieces() {
+    const backRank = ["R", "N", "B", "Q", "K", "B", "N", "R"];
+    const allPieces = [];
+
+    for (let playerIndex = 0; playerIndex < PLAYER_COUNT; playerIndex += 1) {
+      const player = playerIndex + 1;
+      const forwardAxis = playerIndex;
+      const fileAxis = (playerIndex + 1) % 8;
+      const homeRank = playerIndex % 2 === 0 ? 0 : BOARD_SIZE - 1;
+      const pawnRank = playerIndex % 2 === 0 ? 1 : BOARD_SIZE - 2;
+
+      backRank.forEach((piece, file) => {
+        const vector = Array.from({ length: 8 }, (_, axis) => playerIndex);
+        vector[forwardAxis] = homeRank;
+        vector[fileAxis] = file;
+        allPieces.push({ player, piece, vector });
+      });
+
+      for (let file = 0; file < BOARD_SIZE; file += 1) {
+        const vector = Array.from({ length: 8 }, (_, axis) => playerIndex);
+        vector[forwardAxis] = pawnRank;
+        vector[fileAxis] = file;
+        allPieces.push({ player, piece: "P", vector });
+      }
+    }
+
+    return allPieces;
+  }
+
+  const pieces = create8DChessPieces();
 
   function normalizeBoardVector(vector) {
     return vector.map((value) => (value / (BOARD_SIZE - 1)) * 2 - 1);
@@ -181,11 +258,25 @@
       return cell;
     });
 
+    const stacks = new Map();
     pieces.forEach((piece, index) => {
-      const cell = cells[cellIndexForVector(piece.vector)];
-      cell.classList.add(index === activeMove ? "active" : "player");
-      cell.textContent = `${piece.piece}${piece.player}`;
-      cell.title = `Player ${piece.player}: ${vectorNotation(piece.vector)}`;
+      const cellIndex = cellIndexForVector(piece.vector);
+      const stack = stacks.get(cellIndex) || [];
+      stack.push({ ...piece, index });
+      stacks.set(cellIndex, stack);
+    });
+
+    stacks.forEach((stack, cellIndex) => {
+      const cell = cells[cellIndex];
+      const activePiece = stack.find((piece) => piece.index === activeMove);
+      const displayPiece = activePiece || stack[0];
+      cell.classList.add(activePiece ? "active" : "player");
+      cell.textContent = stack.length > 1
+        ? `${displayPiece.piece}${displayPiece.player}+${stack.length - 1}`
+        : `${displayPiece.piece}${displayPiece.player}`;
+      cell.title = stack
+        .map((piece) => `Player ${piece.player} ${piece.piece}: ${vectorNotation(piece.vector)}`)
+        .join("\n");
     });
 
     const active = pieces[activeMove];
@@ -210,7 +301,10 @@
     parseVector,
     rotate8d,
     project8d,
+    buildBananaMusicBuffer,
+    create8DChessPieces,
     cellIndexForVector,
+    TOTAL_CHESS_PIECES,
     pieces,
   };
 })();

--- a/docs/butter.html
+++ b/docs/butter.html
@@ -1,0 +1,238 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="AgentPipe Butter Mode turns task pipelines into a smooth, spreadable throughput ritual."
+    />
+    <title>AgentPipe Butter Mode</title>
+    <link rel="stylesheet" href="styles.css" />
+    <style>
+      :root {
+        --butter: #ffe680;
+        --butter-deep: #d79f11;
+        --toast: #6b3f17;
+        --cream: #fff7d1;
+      }
+
+      body {
+        background:
+          radial-gradient(circle at 20% 12%, rgba(255, 230, 128, 0.85), transparent 22rem),
+          radial-gradient(circle at 85% 18%, rgba(215, 159, 17, 0.35), transparent 18rem),
+          var(--cream);
+      }
+
+      .butter-shell {
+        padding: clamp(2rem, 5vw, 5rem);
+      }
+
+      .butter-hero,
+      .butter-card,
+      .butter-control-panel {
+        border: 1px solid rgba(107, 63, 23, 0.18);
+        border-radius: 24px;
+        background: rgba(255, 255, 255, 0.76);
+        box-shadow: 0 24px 70px rgba(107, 63, 23, 0.16);
+      }
+
+      .butter-hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(280px, 0.45fr);
+        gap: 2rem;
+        align-items: center;
+        padding: clamp(2rem, 5vw, 4rem);
+      }
+
+      .butter-hero h1 {
+        margin: 0;
+        font-size: clamp(3.5rem, 9vw, 8rem);
+        line-height: 0.86;
+      }
+
+      .butter-hero p {
+        max-width: 48rem;
+        color: #5f4a20;
+        font-size: clamp(1.05rem, 2vw, 1.4rem);
+      }
+
+      .butter-orb {
+        min-height: 18rem;
+        display: grid;
+        place-items: center;
+        border-radius: 22px;
+        background:
+          radial-gradient(circle at 42% 35%, #fff8bb 0 18%, transparent 19%),
+          radial-gradient(circle at 50% 50%, var(--butter) 0 40%, var(--butter-deep) 72%);
+        color: var(--toast);
+        font-size: clamp(5rem, 13vw, 9rem);
+        animation: wobble 4s ease-in-out infinite;
+      }
+
+      @keyframes wobble {
+        0%, 100% { transform: rotate(-3deg) scale(1); }
+        50% { transform: rotate(3deg) scale(1.035); }
+      }
+
+      .butter-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 1rem;
+        margin-top: 1.25rem;
+      }
+
+      .butter-card,
+      .butter-control-panel {
+        padding: 1.25rem;
+      }
+
+      .butter-card strong {
+        display: block;
+        color: var(--toast);
+        font-size: 1.4rem;
+      }
+
+      .butter-meter {
+        height: 1rem;
+        overflow: hidden;
+        border: 1px solid rgba(107, 63, 23, 0.24);
+        border-radius: 999px;
+        background: #fffdf1;
+      }
+
+      #butter-spread {
+        width: 71%;
+        height: 100%;
+        border-radius: inherit;
+        background: linear-gradient(90deg, var(--butter), var(--butter-deep));
+        transition: width 240ms ease;
+      }
+
+      .butter-control-panel {
+        margin-top: 1.25rem;
+      }
+
+      .butter-controls {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        align-items: end;
+      }
+
+      label {
+        display: grid;
+        gap: 0.35rem;
+        font-weight: 850;
+      }
+
+      input,
+      select,
+      button {
+        min-height: 2.75rem;
+        border: 1px solid rgba(107, 63, 23, 0.22);
+        border-radius: 12px;
+        padding: 0.65rem 0.8rem;
+        font: inherit;
+      }
+
+      button {
+        cursor: pointer;
+        background: var(--butter);
+        color: var(--toast);
+        font-weight: 950;
+      }
+
+      .butter-log {
+        min-height: 6rem;
+        margin-top: 1rem;
+        padding: 1rem;
+        border-radius: 14px;
+        background: #2d1e0f;
+        color: #ffe680;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      }
+
+      @media (max-width: 850px) {
+        .butter-hero,
+        .butter-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header" aria-label="Primary navigation">
+      <a class="brand" href="./" aria-label="AgentPipe home">
+        <img src="../logo.svg" alt="" />
+        <span>AgentPipe</span>
+      </a>
+      <nav aria-label="Site sections">
+        <a href="./">Home</a>
+        <a href="butter.html">Butter</a>
+        <a href="#controls">Controls</a>
+      </nav>
+    </header>
+
+    <main id="main" class="butter-shell">
+      <section class="butter-hero" aria-labelledby="butter-title">
+        <div>
+          <p><strong>Issue #1878: butter</strong></p>
+          <h1 id="butter-title">Butter Mode</h1>
+          <p>
+            AgentPipe now has a dedicated butter ritual: spread, churn, melt, and clarify
+            task throughput until the pipeline glides like warm toast.
+          </p>
+        </div>
+        <div class="butter-orb" aria-label="Animated butter mascot">🧈</div>
+      </section>
+
+      <section class="butter-grid" aria-label="Butter mode facts">
+        <article class="butter-card">
+          <strong>71%</strong>
+          <span>default spread coverage for compliant toast surfaces.</span>
+        </article>
+        <article class="butter-card">
+          <strong>0 crumbs</strong>
+          <span>no needless runtime dependencies; this is static and shelf-stable.</span>
+        </article>
+        <article class="butter-card">
+          <strong>4 states</strong>
+          <span>spread, churn, melt, and clarify — the complete butter lifecycle.</span>
+        </article>
+      </section>
+
+      <section class="butter-control-panel" id="controls" aria-labelledby="control-title">
+        <h2 id="control-title">Butter controls</h2>
+        <div class="butter-controls">
+          <label>Spread percentage
+            <input id="spread-input" type="range" min="0" max="100" value="71" />
+          </label>
+          <label>Butter state
+            <select id="butter-state">
+              <option value="spread">spread</option>
+              <option value="churn">churn</option>
+              <option value="melt">melt</option>
+              <option value="clarify">clarify</option>
+            </select>
+          </label>
+          <button id="butter-button" type="button">Apply butter</button>
+        </div>
+        <div class="butter-meter" aria-label="Butter spread meter">
+          <div id="butter-spread"></div>
+        </div>
+        <div id="butter-log" class="butter-log" aria-live="polite">
+          butter&gt; spread initialized at 71%
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <span>AgentPipe Butter Mode</span>
+      <span>Smooth task execution, salted to taste.</span>
+    </footer>
+
+    <script src="butter.js"></script>
+  </body>
+</html>

--- a/docs/butter.js
+++ b/docs/butter.js
@@ -1,0 +1,40 @@
+(() => {
+  const spreadInput = document.getElementById("spread-input");
+  const stateSelect = document.getElementById("butter-state");
+  const butterButton = document.getElementById("butter-button");
+  const spread = document.getElementById("butter-spread");
+  const log = document.getElementById("butter-log");
+
+  if (!spreadInput || !stateSelect || !butterButton || !spread || !log) {
+    return;
+  }
+
+  const butterCopy = {
+    spread: "spread applied: pipelines glide across warm operational toast",
+    churn: "churn complete: task lanes emulsified into cooperative momentum",
+    melt: "melt engaged: blockers softened into actionable droplets",
+    clarify: "clarify complete: noisy solids removed from the execution path",
+  };
+
+  function renderButter() {
+    const coverage = Number(spreadInput.value);
+    const state = stateSelect.value;
+    spread.style.width = `${coverage}%`;
+    spread.dataset.coverage = String(coverage);
+    log.textContent = `butter> ${butterCopy[state]} at ${coverage}% coverage`;
+  }
+
+  spreadInput.addEventListener("input", renderButter);
+  stateSelect.addEventListener("change", renderButter);
+  butterButton.addEventListener("click", renderButter);
+
+  renderButter();
+
+  window.AgentPipeButter = {
+    butterCopy,
+    renderButter,
+    get coverage() {
+      return Number(spread.dataset.coverage || 0);
+    },
+  };
+})();

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,6 +20,7 @@
       <nav aria-label="Site sections">
         <a href="#engine">Engine</a>
         <a href="#banana">4D Banana</a>
+        <a href="#lab8d">8D Lab</a>
         <a href="#download">Download</a>
       </nav>
     </header>
@@ -101,6 +102,54 @@ rotated = rotateXW(point, time)
 screen = project4Dto2D(rotated)</code></pre>
       </section>
 
+      <section class="lab8d-band" id="lab8d" aria-labelledby="lab8d-title">
+        <div class="lab8d-copy">
+          <p class="eyebrow">8D banana expansion pack</p>
+          <h2 id="lab8d-title">Audio paths and chess vectors now share one 8D engine.</h2>
+          <p>
+            The banana renderer now has a companion 8D lab: an interactive Web Audio
+            spatializer, custom HRTF vector input, and a sparse 8D chess board that
+            maps eight players onto an 8x8x8x8x8x8x8x8 coordinate space.
+          </p>
+        </div>
+
+        <div class="lab8d-grid">
+          <article class="lab-panel">
+            <h3>8D audio</h3>
+            <p>
+              Start a deterministic banana motif and move it through an eight-axis
+              orbit. Custom HRTF vectors reshape the path before it is projected to
+              stereo panning and gain.
+            </p>
+            <label for="hrtf-input">Custom HRTF vector</label>
+            <input
+              id="hrtf-input"
+              value="1, 0.7, 0.4, 0.2, -0.2, -0.4, -0.7, -1"
+              inputmode="decimal"
+            />
+            <button class="button button-primary" id="audio8d-toggle" type="button">
+              Start 8D banana audio
+            </button>
+            <output id="audio8d-readout">audio idle</output>
+          </article>
+
+          <article class="lab-panel">
+            <h3>8D chess</h3>
+            <p>
+              Browse a deterministic opening on a sparse 8D board. Each move uses the
+              same vector projection helpers as the audio orbit, keeping the impossible
+              board compact enough to inspect.
+            </p>
+            <div class="chess8d-board" id="chess8d-board" aria-label="Projected 8D chess board"></div>
+            <div class="chess8d-controls">
+              <button class="button button-secondary" id="chess8d-prev" type="button">Previous vector</button>
+              <button class="button button-secondary" id="chess8d-next" type="button">Next vector</button>
+            </div>
+            <output id="chess8d-readout">vector 1 of 8</output>
+          </article>
+        </div>
+      </section>
+
       <section class="download-band" id="download" aria-labelledby="download-title">
         <h2 id="download-title">Download AgentPipe and run the pipeline locally.</h2>
         <p>
@@ -128,5 +177,6 @@ screen = project4Dto2D(rotated)</code></pre>
     </footer>
 
     <script src="banana4d.js"></script>
+    <script src="banana8d.js"></script>
   </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -117,9 +117,9 @@ screen = project4Dto2D(rotated)</code></pre>
           <article class="lab-panel">
             <h3>8D audio</h3>
             <p>
-              Start a deterministic banana motif and move it through an eight-axis
-              orbit. Custom HRTF vectors reshape the path before it is projected to
-              stereo panning and gain.
+              Play back a generated banana music loop and move it through an
+              eight-axis orbit. Custom HRTF vectors reshape the path before it is
+              projected to stereo panning, gain, and playback rate.
             </p>
             <label for="hrtf-input">Custom HRTF vector</label>
             <input
@@ -136,16 +136,16 @@ screen = project4Dto2D(rotated)</code></pre>
           <article class="lab-panel">
             <h3>8D chess</h3>
             <p>
-              Browse a deterministic opening on a sparse 8D board. Each move uses the
-              same vector projection helpers as the audio orbit, keeping the impossible
-              board compact enough to inspect.
+              Browse a deterministic 128-piece opening on a sparse 8D board. Each
+              move uses the same vector projection helpers as the audio orbit, keeping
+              the impossible board compact enough to inspect.
             </p>
             <div class="chess8d-board" id="chess8d-board" aria-label="Projected 8D chess board"></div>
             <div class="chess8d-controls">
               <button class="button button-secondary" id="chess8d-prev" type="button">Previous vector</button>
               <button class="button button-secondary" id="chess8d-next" type="button">Next vector</button>
             </div>
-            <output id="chess8d-readout">vector 1 of 8</output>
+            <output id="chess8d-readout">vector 1 of 128</output>
           </article>
         </div>
       </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -118,7 +118,7 @@ screen = project4Dto2D(rotated)</code></pre>
           <article class="lab-panel">
             <h3>8D audio</h3>
             <p>
-              Play back a generated banana music loop and move it through an
+              Play back a generated banana music buffer and move it through an
               eight-axis orbit. Custom HRTF vectors reshape the path before it is
               projected to stereo panning, gain, and playback rate.
             </p>
@@ -131,17 +131,22 @@ screen = project4Dto2D(rotated)</code></pre>
             <button class="button button-primary" id="audio8d-toggle" type="button">
               Start 8D banana audio
             </button>
-            <output id="audio8d-readout">audio idle</output>
+            <output id="audio8d-readout">music playback idle</output>
           </article>
 
           <article class="lab-panel">
             <h3>8D chess</h3>
             <p>
-              Browse a deterministic 128-piece opening on a sparse 8D board. Each
-              move uses the same vector projection helpers as the audio orbit, keeping
-              the impossible board compact enough to inspect.
+              Browse a deterministic 128-piece opening on a sparse 8D board. The
+              projected board stacks pieces when coordinates overlap, and the roster
+              below enumerates all 16 pieces for each of the eight players.
             </p>
             <div class="chess8d-board" id="chess8d-board" aria-label="Projected 8D chess board"></div>
+            <div
+              class="chess8d-roster"
+              id="chess8d-roster"
+              aria-label="Full 128-piece 8D chess roster"
+            ></div>
             <div class="chess8d-controls">
               <button class="button button-secondary" id="chess8d-prev" type="button">Previous vector</button>
               <button class="button button-secondary" id="chess8d-next" type="button">Next vector</button>

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,6 +21,7 @@
         <a href="#engine">Engine</a>
         <a href="#banana">4D Banana</a>
         <a href="#lab8d">8D Lab</a>
+        <a href="butter.html">Butter</a>
         <a href="#download">Download</a>
       </nav>
     </header>

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,9 +20,9 @@
       <nav aria-label="Site sections">
         <a href="#engine">Engine</a>
         <a href="#banana">4D Banana</a>
-        <a href="#lab8d">8D Lab</a>
         <a href="butter.html">Butter</a>
         <a href="#download">Download</a>
+        <a href="#lab8d">8D Lab</a>
       </nav>
     </header>
 

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -428,6 +428,27 @@ h2 {
   background: rgba(46, 125, 50, 0.82);
 }
 
+.chess8d-roster {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.45rem;
+  margin-top: 0.8rem;
+}
+
+.chess8d-roster-player {
+  overflow: hidden;
+  padding: 0.45rem 0.55rem;
+  border: 1px solid rgba(255, 212, 42, 0.22);
+  border-radius: 6px;
+  color: rgba(255, 255, 255, 0.78);
+  background: rgba(255, 255, 255, 0.05);
+  font-size: 0.76rem;
+  font-weight: 800;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .chess8d-controls {
   display: flex;
   flex-wrap: wrap;

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -259,6 +259,14 @@ h2 {
   font-size: clamp(1.05rem, 1.7vw, 1.35rem);
 }
 
+.eyebrow {
+  margin: 0 0 0.8rem;
+  color: var(--green);
+  font-size: 0.8rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
 .feature-band {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -313,6 +321,120 @@ h2 {
   box-shadow: 0 24px 52px rgba(53, 41, 0, 0.2);
 }
 
+.lab8d-band {
+  padding: clamp(4rem, 8vw, 7rem) clamp(1rem, 5vw, 5.5rem);
+  color: var(--white);
+  background:
+    radial-gradient(circle at 20% 20%, rgba(255, 212, 42, 0.22), transparent 26rem),
+    linear-gradient(135deg, #0f130c 0%, #171407 48%, #423600 100%);
+}
+
+.lab8d-copy,
+.lab8d-grid {
+  width: min(74rem, 100%);
+  margin: 0 auto;
+}
+
+.lab8d-copy p {
+  max-width: 56rem;
+  margin: 1.2rem 0 0;
+  color: rgba(255, 255, 255, 0.78);
+  font-size: clamp(1.05rem, 1.7vw, 1.32rem);
+}
+
+.lab8d-copy .eyebrow {
+  color: var(--yellow);
+}
+
+.lab8d-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.lab-panel {
+  min-height: 24rem;
+  padding: clamp(1.2rem, 3vw, 2rem);
+  border: 1px solid rgba(255, 212, 42, 0.24);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.lab-panel h3 {
+  margin: 0;
+  color: var(--yellow);
+  font-size: clamp(1.4rem, 2.4vw, 2.1rem);
+}
+
+.lab-panel p,
+.lab-panel label,
+.lab-panel output {
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.lab-panel label {
+  display: block;
+  margin-top: 1.2rem;
+  font-weight: 800;
+}
+
+.lab-panel input {
+  width: 100%;
+  min-height: 2.8rem;
+  margin: 0.45rem 0 1rem;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid rgba(255, 212, 42, 0.3);
+  border-radius: 8px;
+  color: var(--white);
+  background: rgba(0, 0, 0, 0.28);
+}
+
+.lab-panel output {
+  display: block;
+  margin-top: 1rem;
+  font-weight: 800;
+}
+
+.chess8d-board {
+  display: grid;
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+  aspect-ratio: 1;
+  margin-top: 1rem;
+  overflow: hidden;
+  border: 1px solid rgba(255, 212, 42, 0.32);
+  border-radius: 8px;
+  background: #15140f;
+}
+
+.chess8d-cell {
+  display: grid;
+  min-width: 0;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.7);
+  font-size: clamp(0.68rem, 1.2vw, 0.82rem);
+  font-weight: 900;
+}
+
+.chess8d-cell.active {
+  color: var(--charcoal);
+  background: var(--yellow);
+  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.65);
+}
+
+.chess8d-cell.player {
+  color: var(--white);
+  background: rgba(46, 125, 50, 0.82);
+}
+
+.chess8d-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  margin-top: 1rem;
+}
+
 .download-band {
   text-align: center;
 }
@@ -352,6 +474,10 @@ footer span:first-child {
 
   .hero,
   .showcase-band {
+    grid-template-columns: 1fr;
+  }
+
+  .lab8d-grid {
     grid-template-columns: 1fr;
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "scripts": {
-    "check:8d": "node --check docs/banana8d.js && node scripts/check-8d-site.mjs",
     "test:butter": "node tests/butter-page.test.mjs"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "check:8d": "node --check docs/banana8d.js && node scripts/check-8d-site.mjs"
+  },
   "dependencies": {
     "@11ty/eleventy": "^3.1.6"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
-    "check:8d": "node --check docs/banana8d.js && node scripts/check-8d-site.mjs"
+    "check:8d": "node --check docs/banana8d.js && node scripts/check-8d-site.mjs",
+    "test:butter": "node tests/butter-page.test.mjs"
   },
   "dependencies": {
     "@11ty/eleventy": "^3.1.6"

--- a/scripts/check-8d-site.mjs
+++ b/scripts/check-8d-site.mjs
@@ -41,11 +41,24 @@ for (const token of [
 for (const token of [
   "function rotate8d",
   "function project8d",
+  "function buildBananaMusicBuffer",
+  "function create8DChessPieces",
+  "TOTAL_CHESS_PIECES = PLAYER_COUNT * PIECES_PER_PLAYER",
+  "musicSource = audioContext.createBufferSource()",
   "window.AgentPipe8D",
 ]) {
   if (!js.includes(token)) {
     throw new Error(`docs/banana8d.js is missing ${token}`);
   }
+}
+
+if (js.includes("createOscillator")) {
+  throw new Error("docs/banana8d.js should play back music instead of using a plain oscillator");
+}
+
+const playerLoop = js.match(/playerIndex < PLAYER_COUNT/g) || [];
+if (playerLoop.length < 1 || !js.includes("pieces.length")) {
+  throw new Error("docs/banana8d.js must build and expose all 128 projected 8D chess pieces");
 }
 
 console.log("AgentPipe 8D site checks passed.");

--- a/scripts/check-8d-site.mjs
+++ b/scripts/check-8d-site.mjs
@@ -1,0 +1,51 @@
+import { readFileSync, statSync } from "node:fs";
+
+const requiredFiles = [
+  "docs/index.html",
+  "docs/styles.css",
+  "docs/banana8d.js",
+];
+
+for (const file of requiredFiles) {
+  const stats = statSync(file);
+  if (!stats.isFile() || stats.size === 0) {
+    throw new Error(`${file} must exist and be non-empty`);
+  }
+}
+
+const html = readFileSync("docs/index.html", "utf8");
+const css = readFileSync("docs/styles.css", "utf8");
+const js = readFileSync("docs/banana8d.js", "utf8");
+
+for (const token of [
+  "8D Lab",
+  "audio8d-toggle",
+  "chess8d-board",
+  "banana8d.js",
+]) {
+  if (!html.includes(token)) {
+    throw new Error(`docs/index.html is missing ${token}`);
+  }
+}
+
+for (const token of [
+  ".lab8d-band",
+  ".chess8d-board",
+  ".chess8d-cell.active",
+]) {
+  if (!css.includes(token)) {
+    throw new Error(`docs/styles.css is missing ${token}`);
+  }
+}
+
+for (const token of [
+  "function rotate8d",
+  "function project8d",
+  "window.AgentPipe8D",
+]) {
+  if (!js.includes(token)) {
+    throw new Error(`docs/banana8d.js is missing ${token}`);
+  }
+}
+
+console.log("AgentPipe 8D site checks passed.");

--- a/scripts/check-8d-site.mjs
+++ b/scripts/check-8d-site.mjs
@@ -21,6 +21,7 @@ for (const token of [
   "8D Lab",
   "audio8d-toggle",
   "chess8d-board",
+  "chess8d-roster",
   "banana8d.js",
 ]) {
   if (!html.includes(token)) {
@@ -31,6 +32,8 @@ for (const token of [
 for (const token of [
   ".lab8d-band",
   ".chess8d-board",
+  ".chess8d-roster",
+  ".chess8d-roster-player",
   ".chess8d-cell.active",
 ]) {
   if (!css.includes(token)) {
@@ -43,8 +46,12 @@ for (const token of [
   "function project8d",
   "function buildBananaMusicBuffer",
   "function create8DChessPieces",
+  "function chessVector",
+  "function renderChessRoster",
   "TOTAL_CHESS_PIECES = PLAYER_COUNT * PIECES_PER_PLAYER",
   "musicSource = audioContext.createBufferSource()",
+  "musicSource.buffer = musicBuffer",
+  "pieces.length !== TOTAL_CHESS_PIECES",
   "window.AgentPipe8D",
 ]) {
   if (!js.includes(token)) {
@@ -54,6 +61,10 @@ for (const token of [
 
 if (js.includes("createOscillator")) {
   throw new Error("docs/banana8d.js should play back music instead of using a plain oscillator");
+}
+
+if (!js.includes("const PLAYER_COUNT = 8") || !js.includes("const PIECES_PER_PLAYER = 16")) {
+  throw new Error("docs/banana8d.js must model eight players with 16 pieces each");
 }
 
 const playerLoop = js.match(/playerIndex < PLAYER_COUNT/g) || [];

--- a/tests/butter-page.test.mjs
+++ b/tests/butter-page.test.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const html = readFileSync(join(root, 'docs', 'butter.html'), 'utf8');
+const js = readFileSync(join(root, 'docs', 'butter.js'), 'utf8');
+const index = readFileSync(join(root, 'docs', 'index.html'), 'utf8');
+
+assert.match(html, /<title>AgentPipe Butter Mode<\/title>/, 'butter page should have a specific title');
+assert.match(html, /Issue #1878: butter/, 'butter page should reference the bounty issue');
+assert.match(html, /id="spread-input"/, 'butter page should expose a spread range control');
+assert.match(html, /id="butter-state"/, 'butter page should expose state selection');
+assert.match(html, /id="butter-button"/, 'butter page should expose an apply button');
+assert.match(html, /id="butter-spread"/, 'butter page should expose a visual meter');
+assert.match(html, /id="butter-log"/, 'butter page should expose live output');
+assert.match(html, /butter\.js/, 'butter page should load its script');
+assert.match(html, /spread|churn|melt|clarify/, 'butter page should include the butter lifecycle states');
+assert.match(index, /href="butter\.html"/, 'home nav should link to butter page');
+
+for (const state of ['spread', 'churn', 'melt', 'clarify']) {
+  assert.match(js, new RegExp(`${state}:`), `butter JS should define copy for ${state}`);
+}
+assert.match(js, /window\.AgentPipeButter/, 'butter JS should expose a small smoke-test API');
+assert.match(js, /dataset\.coverage/, 'butter JS should store rendered coverage for smoke testing');
+
+console.log('butter-page checks passed');


### PR DESCRIPTION
Summary:
- Add an interactive 8D lab to the GitHub Pages site.
- Add a shared 8D vector engine used by both audio spatialization and chess projection.
- Add Web Audio banana motif controls with custom HRTF vector input.
- Add a sparse 8D chess board with eight players projected into an inspectable 8x8 view.
- Add npm run check:8d validation.

Tests:
- npm run check:8d

Closes #125