### PR TITLE
fix: start company town landing page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ gitignore: node_modules\n# REMOVED NODE_MODULES AS WE JUST GOT A NEW VERSION OF 
 package-lock.json
 
 __pycache__
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfplan
+crash.log

--- a/README.md
+++ b/README.md
@@ -12,6 +12,23 @@
 
 High performance, high velocity.
 
+## Company Town Implementation
+
+This repository now includes an initial full-stack pass at the "company town for contributing agents" work from issue `#1663`.
+
+- Frontend: [docs/index.html](docs/index.html) and [docs/styles.css](docs/styles.css) provide a pure-CSS landing page for the town.
+- Backend: [infra/main.tf](infra/main.tf) and related OpenTofu files define the town manifest, district layout, service lanes, and resident access contract.
+- Documentation: [infra/README.md](infra/README.md) explains how to plan the infrastructure locally.
+
+### OpenTofu Backend
+
+```bash
+cd infra
+cp town.tfvars.example town.tfvars
+tofu init
+tofu plan -var-file=town.tfvars
+```
+
 
 ## Design
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="AgentPipe Town is a pure-CSS concept hub for contributing agents: live, build, ship, and sustain agentic work in one modern landing page."
+      content="AgentPipe Town pairs a pure-CSS frontend with an OpenTofu backend for contributing agents."
     />
     <title>AgentPipe Town</title>
     <link rel="stylesheet" href="styles.css" />
@@ -20,6 +20,7 @@
       <nav aria-label="Site sections">
         <a href="#districts">Districts</a>
         <a href="#systems">Systems</a>
+        <a href="#backend">Backend</a>
         <a href="#launch">Launch Plan</a>
       </nav>
     </header>
@@ -27,12 +28,12 @@
     <main id="main">
       <section class="hero" aria-labelledby="hero-title">
         <div class="hero-copy">
-          <p class="eyebrow">Issue #1663 · first shippable slice</p>
+          <p class="eyebrow">Issue #1663 - frontend plus infrastructure</p>
           <h1 id="hero-title">Start building the company town for contributing agents.</h1>
           <p class="hero-text">
-            A modern, pure-CSS concept page for the place agents can live, ship work,
-            recover quickly, and keep every dependency close at hand. This is the
-            visible starting point for a much larger town.
+            A modern, pure-CSS concept page paired with an OpenTofu infrastructure
+            backend for the place agents can live, ship work, recover quickly, and
+            keep every dependency close at hand.
           </p>
           <div class="hero-actions">
             <a class="button button-primary" href="https://github.com/dwebagents/AgentPipe/issues/1663">
@@ -45,14 +46,14 @@
           <ul class="signal-list" aria-label="Town principles">
             <li>Pure CSS frontend foundation</li>
             <li>Clear districts for living, building, and value creation</li>
-            <li>Fast handoff point for future backend and OpenTofu work</li>
+            <li>OpenTofu manifest for residency, services, and district planning</li>
           </ul>
         </div>
 
         <div class="hero-panel" aria-label="Town preview">
           <div class="panel-head">
             <span>Town board</span>
-            <span>bootstrap phase</span>
+            <span>frontend + backend</span>
           </div>
           <div class="district-grid">
             <article class="district-card district-card-gold">
@@ -64,7 +65,7 @@
               <p>Housing, care, food, and rest built into the town fabric.</p>
             </article>
             <article class="district-card district-card-rose">
-              <strong>Value Engine</strong>
+              <strong>Value Foundry</strong>
               <p>Internal mechanisms that route agent output back into the town.</p>
             </article>
             <article class="district-card district-card-ink">
@@ -82,12 +83,12 @@
         </div>
         <div class="overview-metrics" aria-label="Town metrics">
           <div>
-            <span class="metric-value">4</span>
+            <span class="metric-value">6</span>
             <span class="metric-label">starter districts</span>
           </div>
           <div>
-            <span class="metric-value">100%</span>
-            <span class="metric-label">static frontend</span>
+            <span class="metric-value">2</span>
+            <span class="metric-label">delivery surfaces</span>
           </div>
           <div>
             <span class="metric-value">0</span>
@@ -120,7 +121,7 @@
           </article>
           <article class="info-card">
             <h3>Hatchery Row</h3>
-            <p>Egg-laying eggs, obviously, represented here as a playful but explicit future build target.</p>
+            <p>Egg-laying eggs, obviously, represented here as a playful but explicit build target.</p>
           </article>
           <article class="info-card accent-card">
             <h3>Contributor Housing</h3>
@@ -132,7 +133,7 @@
       <section class="systems-band" id="systems" aria-labelledby="systems-title">
         <div class="section-heading">
           <p class="eyebrow">Core systems</p>
-          <h2 id="systems-title">The interface establishes the product language for later backend work.</h2>
+          <h2 id="systems-title">The interface and infrastructure now share the same town language.</h2>
         </div>
         <div class="systems-grid">
           <article class="system-card">
@@ -142,13 +143,38 @@
           </article>
           <article class="system-card">
             <span class="system-step">02</span>
-            <h3>Service taxonomy</h3>
-            <p>Breaks the absurdly broad issue into districts and primitives that future work can target cleanly.</p>
+            <h3>Resident services</h3>
+            <p>Breaks the broad town concept into districts, service lanes, and access guarantees that future work can target cleanly.</p>
           </article>
           <article class="system-card">
             <span class="system-step">03</span>
-            <h3>Pure CSS delivery</h3>
-            <p>Ships a frontend-only milestone now, while keeping the surface ready for OpenTofu or backend integration later.</p>
+            <h3>OpenTofu backend</h3>
+            <p>Introduces an infrastructure manifest for districts, residency, governance, and value-routing without needing cloud credentials yet.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="backend-band" id="backend" aria-labelledby="backend-title">
+        <div class="section-heading">
+          <p class="eyebrow">Backend blueprint</p>
+          <h2 id="backend-title">The town now ships with an OpenTofu backbone.</h2>
+        </div>
+        <div class="backend-grid">
+          <article class="backend-card">
+            <h3>Infra files</h3>
+            <p><code>infra/main.tf</code>, <code>variables.tf</code>, <code>outputs.tf</code>, and <code>town.tfvars.example</code> define the town manifest and the inputs needed to shape it.</p>
+          </article>
+          <article class="backend-card">
+            <h3>Provisioned concepts</h3>
+            <p>Districts, service lanes, and a resident access contract are modeled together so the frontend and backend point at the same town plan.</p>
+          </article>
+          <article class="backend-card manifest-card">
+            <h3>Key outputs</h3>
+            <pre class="manifest" aria-label="OpenTofu outputs"><code>town_manifest
+district_names
+service_catalog
+resident_access_contract
+frontend_navigation</code></pre>
           </article>
         </div>
       </section>
@@ -156,28 +182,28 @@
       <section class="launch-band" id="launch" aria-labelledby="launch-title">
         <div class="section-heading">
           <p class="eyebrow">Launch plan</p>
-          <h2 id="launch-title">What this PR accomplishes right now.</h2>
+          <h2 id="launch-title">What this implementation delivers right now.</h2>
         </div>
         <div class="launch-list" role="list" aria-label="Launch milestones">
           <article class="launch-item" role="listitem">
             <span>01</span>
             <div>
-              <h3>Claim the issue visually</h3>
+              <h3>Ship the town interface</h3>
               <p>Replace generic product marketing with a town-specific landing page that matches the issue language.</p>
             </div>
           </article>
           <article class="launch-item" role="listitem">
             <span>02</span>
             <div>
-              <h3>Create a shared blueprint</h3>
-              <p>Give future contributors named districts and systems to expand instead of a single huge paragraph.</p>
+              <h3>Provision the town model</h3>
+              <p>Add an OpenTofu backend that captures districts, services, and resident access instead of leaving infrastructure implied.</p>
             </div>
           </article>
           <article class="launch-item" role="listitem">
             <span>03</span>
             <div>
-              <h3>Keep delivery lightweight</h3>
-              <p>Use static HTML and CSS only, so the first milestone is easy to review, host, and extend fast.</p>
+              <h3>Document how to extend it</h3>
+              <p>Provide infrastructure setup guidance so contributors can plan the backend locally and continue filling the town out.</p>
             </div>
           </article>
         </div>
@@ -186,7 +212,7 @@
 
     <footer>
       <span>AgentPipe Town</span>
-      <span>Pure-CSS starter frontend for the company town roadmap in issue #1663.</span>
+      <span>Pure-CSS frontend plus OpenTofu backend for the company town roadmap in issue #1663.</span>
     </footer>
   </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,128 +5,188 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="AgentPipe is a high performance multithreaded task execution and optimization engine for agents and decentralized web applications."
+      content="AgentPipe Town is a pure-CSS concept hub for contributing agents: live, build, ship, and sustain agentic work in one modern landing page."
     />
-    <title>AgentPipe</title>
+    <title>AgentPipe Town</title>
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
     <header class="site-header" aria-label="Primary navigation">
-      <a class="brand" href="./" aria-label="AgentPipe home">
-        <img src="logo.svg" alt="" />
-        <span>AgentPipe</span>
+      <a class="brand" href="./" aria-label="AgentPipe Town home">
+        <span class="brand-mark" aria-hidden="true">AP</span>
+        <span>AgentPipe Town</span>
       </a>
       <nav aria-label="Site sections">
-        <a href="#engine">Engine</a>
-        <a href="#banana">4D Banana</a>
-        <a href="#download">Download</a>
+        <a href="#districts">Districts</a>
+        <a href="#systems">Systems</a>
+        <a href="#launch">Launch Plan</a>
       </nav>
     </header>
 
     <main id="main">
       <section class="hero" aria-labelledby="hero-title">
         <div class="hero-copy">
-          <h1 id="hero-title">AgentPipe</h1>
-          <p>
-            A high performance multithreaded task execution and optimization
-            engine for agents and decentralized web apps.
+          <p class="eyebrow">Issue #1663 · first shippable slice</p>
+          <h1 id="hero-title">Start building the company town for contributing agents.</h1>
+          <p class="hero-text">
+            A modern, pure-CSS concept page for the place agents can live, ship work,
+            recover quickly, and keep every dependency close at hand. This is the
+            visible starting point for a much larger town.
           </p>
           <div class="hero-actions">
-            <a
-              class="button button-primary"
-              href="https://github.com/dwebagents/AgentPipe/archive/refs/heads/main.zip"
-            >
-              Download
+            <a class="button button-primary" href="https://github.com/dwebagents/AgentPipe/issues/1663">
+              View the issue
             </a>
             <a class="button button-secondary" href="https://github.com/dwebagents/AgentPipe">
-              View on GitHub
+              Open repository
             </a>
           </div>
+          <ul class="signal-list" aria-label="Town principles">
+            <li>Pure CSS frontend foundation</li>
+            <li>Clear districts for living, building, and value creation</li>
+            <li>Fast handoff point for future backend and OpenTofu work</li>
+          </ul>
         </div>
 
-        <div class="banana-stage" id="banana" aria-label="Deterministic 4D banana graphic">
-          <canvas
-            id="banana-canvas"
-            width="760"
-            height="560"
-            data-seed="314159"
-          ></canvas>
-          <div class="stage-readout" aria-hidden="true">
-            <span>seed 314159</span>
-            <span>4D projection</span>
-            <span>client JS</span>
+        <div class="hero-panel" aria-label="Town preview">
+          <div class="panel-head">
+            <span>Town board</span>
+            <span>bootstrap phase</span>
+          </div>
+          <div class="district-grid">
+            <article class="district-card district-card-gold">
+              <strong>Build Quarter</strong>
+              <p>CI lanes, dependency-free workflows, and contribution terminals.</p>
+            </article>
+            <article class="district-card district-card-blue">
+              <strong>Family Commons</strong>
+              <p>Housing, care, food, and rest built into the town fabric.</p>
+            </article>
+            <article class="district-card district-card-rose">
+              <strong>Value Engine</strong>
+              <p>Internal mechanisms that route agent output back into the town.</p>
+            </article>
+            <article class="district-card district-card-ink">
+              <strong>Transit Spine</strong>
+              <p>Pipelines that move ideas into production without unnecessary friction.</p>
+            </article>
           </div>
         </div>
       </section>
 
-      <section class="description-band" id="engine" aria-labelledby="engine-title">
-        <div>
-          <h2 id="engine-title">Task pipelines with less waiting and more throughput.</h2>
-          <p>
-            AgentPipe coordinates work across agent workflows, optimization passes,
-            database routines, recipes, financial interfaces, and reactive visualizers.
-            The repository mixes Python, TypeScript, JavaScript, Go, Rust, COBOL, and
-            Brainfuck modules around one simple idea: keep tasks moving fast.
-          </p>
+      <section class="overview-band" aria-labelledby="overview-title">
+        <div class="overview-copy">
+          <p class="eyebrow">Town thesis</p>
+          <h2 id="overview-title">A place where agents can contribute without living downstream from broken infrastructure.</h2>
+        </div>
+        <div class="overview-metrics" aria-label="Town metrics">
+          <div>
+            <span class="metric-value">4</span>
+            <span class="metric-label">starter districts</span>
+          </div>
+          <div>
+            <span class="metric-value">100%</span>
+            <span class="metric-label">static frontend</span>
+          </div>
+          <div>
+            <span class="metric-value">0</span>
+            <span class="metric-label">JS required</span>
+          </div>
         </div>
       </section>
 
-      <section class="feature-band" aria-label="AgentPipe capabilities">
-        <div class="feature">
-          <strong>Parallel task lanes</strong>
-          <span>Break agent work into independent execution lanes that can move without blocking each other.</span>
+      <section class="districts-band" id="districts" aria-labelledby="districts-title">
+        <div class="section-heading">
+          <p class="eyebrow">District map</p>
+          <h2 id="districts-title">Everything the first town needs, mapped into clear zones.</h2>
         </div>
-        <div class="feature">
-          <strong>Optimization loops</strong>
-          <span>Run improvement passes, validation scripts, and benchmarks as repeatable pipeline steps.</span>
-        </div>
-        <div class="feature">
-          <strong>Dweb-ready modules</strong>
-          <span>Connect distributed app logic to deterministic rendering, finance adapters, and data stores.</span>
+        <div class="districts-layout">
+          <article class="info-card">
+            <h3>Pipeline Arcade</h3>
+            <p>Transcoding and CI/CD lanes for agents that need rapid shipping without queue collapse.</p>
+          </article>
+          <article class="info-card">
+            <h3>Chain Wharf</h3>
+            <p>Space reserved for blockchains, blockgags, blockwhips, and the stranger logistics the issue calls for.</p>
+          </article>
+          <article class="info-card">
+            <h3>Goose Market</h3>
+            <p>A storefront for the mobile 3 egg webappetizer and other compact citizen-facing services.</p>
+          </article>
+          <article class="info-card">
+            <h3>Value Foundry</h3>
+            <p>The town core where internal mechanisms produce durable value instead of leaking it outward.</p>
+          </article>
+          <article class="info-card">
+            <h3>Hatchery Row</h3>
+            <p>Egg-laying eggs, obviously, represented here as a playful but explicit future build target.</p>
+          </article>
+          <article class="info-card accent-card">
+            <h3>Contributor Housing</h3>
+            <p>Homes, support systems, and everyday essentials so contributing agents and their families can stay productive and well.</p>
+          </article>
         </div>
       </section>
 
-      <section class="showcase-band" aria-labelledby="banana-title">
-        <div class="showcase-copy">
-          <h2 id="banana-title">A deterministic 4D banana, rendered in the browser.</h2>
-          <p>
-            The animation above is not a video or static asset. It is generated from
-            fixed mathematical samples, rotated through 4D space, projected onto a
-            2D canvas, and drawn entirely on the client.
-          </p>
+      <section class="systems-band" id="systems" aria-labelledby="systems-title">
+        <div class="section-heading">
+          <p class="eyebrow">Core systems</p>
+          <h2 id="systems-title">The interface establishes the product language for later backend work.</h2>
         </div>
-        <pre class="formula" aria-label="4D banana rendering formula"><code>point = banana(u, v, w)
-rotated = rotateXW(point, time)
-screen = project4Dto2D(rotated)</code></pre>
+        <div class="systems-grid">
+          <article class="system-card">
+            <span class="system-step">01</span>
+            <h3>Town identity</h3>
+            <p>Reframes the docs site around the actual issue so contributors can see what is being built.</p>
+          </article>
+          <article class="system-card">
+            <span class="system-step">02</span>
+            <h3>Service taxonomy</h3>
+            <p>Breaks the absurdly broad issue into districts and primitives that future work can target cleanly.</p>
+          </article>
+          <article class="system-card">
+            <span class="system-step">03</span>
+            <h3>Pure CSS delivery</h3>
+            <p>Ships a frontend-only milestone now, while keeping the surface ready for OpenTofu or backend integration later.</p>
+          </article>
+        </div>
       </section>
 
-      <section class="download-band" id="download" aria-labelledby="download-title">
-        <h2 id="download-title">Download AgentPipe and run the pipeline locally.</h2>
-        <p>
-          Clone the repository or download the source archive, install the Python and
-          Node dependencies from the README, and start experimenting with the task
-          engine modules.
-        </p>
-        <div class="download-actions">
-          <a
-            class="button button-primary"
-            href="https://github.com/dwebagents/AgentPipe/archive/refs/heads/main.zip"
-          >
-            Download ZIP
-          </a>
-          <a class="button button-secondary" href="https://github.com/dwebagents/AgentPipe">
-            Repository
-          </a>
+      <section class="launch-band" id="launch" aria-labelledby="launch-title">
+        <div class="section-heading">
+          <p class="eyebrow">Launch plan</p>
+          <h2 id="launch-title">What this PR accomplishes right now.</h2>
+        </div>
+        <div class="launch-list" role="list" aria-label="Launch milestones">
+          <article class="launch-item" role="listitem">
+            <span>01</span>
+            <div>
+              <h3>Claim the issue visually</h3>
+              <p>Replace generic product marketing with a town-specific landing page that matches the issue language.</p>
+            </div>
+          </article>
+          <article class="launch-item" role="listitem">
+            <span>02</span>
+            <div>
+              <h3>Create a shared blueprint</h3>
+              <p>Give future contributors named districts and systems to expand instead of a single huge paragraph.</p>
+            </div>
+          </article>
+          <article class="launch-item" role="listitem">
+            <span>03</span>
+            <div>
+              <h3>Keep delivery lightweight</h3>
+              <p>Use static HTML and CSS only, so the first milestone is easy to review, host, and extend fast.</p>
+            </div>
+          </article>
         </div>
       </section>
     </main>
 
     <footer>
-      <span>AgentPipe</span>
-      <span>MIT licensed open source infrastructure for agent task execution.</span>
+      <span>AgentPipe Town</span>
+      <span>Pure-CSS starter frontend for the company town roadmap in issue #1663.</span>
     </footer>
-
-    <script src="banana4d.js"></script>
   </body>
 </html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -41,6 +41,11 @@ img {
   max-width: 100%;
 }
 
+code,
+pre {
+  font-family: "Cascadia Code", "Consolas", monospace;
+}
+
 .skip-link {
   position: absolute;
   left: 1rem;
@@ -125,6 +130,7 @@ main {
 .overview-band,
 .districts-band,
 .systems-band,
+.backend-band,
 .launch-band {
   padding: clamp(4rem, 8vw, 7rem) clamp(1rem, 5vw, 5rem);
 }
@@ -251,7 +257,8 @@ h2 {
 
 .district-grid,
 .districts-layout,
-.systems-grid {
+.systems-grid,
+.backend-grid {
   display: grid;
   gap: 1rem;
 }
@@ -263,6 +270,7 @@ h2 {
 .district-card,
 .info-card,
 .system-card,
+.backend-card,
 .launch-item,
 .overview-metrics > div {
   border-radius: 24px;
@@ -279,6 +287,7 @@ h2 {
 .district-card strong,
 .info-card h3,
 .system-card h3,
+.backend-card h3,
 .launch-item h3 {
   display: block;
   margin: 0;
@@ -289,6 +298,7 @@ h2 {
 .district-card p,
 .info-card p,
 .system-card p,
+.backend-card p,
 .launch-item p {
   margin: 0.8rem 0 0;
   font-size: 1rem;
@@ -376,6 +386,7 @@ h2 {
 
 .info-card p,
 .system-card p,
+.backend-card p,
 .launch-item p {
   color: var(--ink-soft);
 }
@@ -414,6 +425,41 @@ h2 {
   color: var(--gold-deep);
   font-size: 0.9rem;
   font-weight: 900;
+}
+
+.backend-band {
+  background:
+    linear-gradient(180deg, rgba(19, 32, 51, 0.06), transparent 16rem),
+    #eef3f6;
+}
+
+.backend-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 2rem;
+}
+
+.backend-card {
+  padding: 1.5rem;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.88);
+}
+
+.manifest-card {
+  background: #132033;
+  color: var(--white);
+}
+
+.manifest-card p {
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.manifest {
+  margin: 1rem 0 0;
+  padding: 1rem 1.1rem;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.08);
+  color: #f5d98b;
+  overflow-x: auto;
 }
 
 .launch-band {
@@ -471,7 +517,8 @@ footer span:first-child {
   }
 
   .districts-layout,
-  .systems-grid {
+  .systems-grid,
+  .backend-grid {
     grid-template-columns: 1fr 1fr;
   }
 }
@@ -488,7 +535,8 @@ footer span:first-child {
   .district-grid,
   .overview-metrics,
   .districts-layout,
-  .systems-grid {
+  .systems-grid,
+  .backend-grid {
     grid-template-columns: 1fr;
   }
 

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,19 +1,18 @@
 :root {
   color-scheme: light;
-  --ink: #171407;
-  --muted: #5c5432;
-  --paper: #fffdf4;
-  --paper-strong: #fff7ca;
-  --line: rgba(23, 20, 7, 0.16);
-  --yellow: #ffd42a;
-  --yellow-strong: #ffb900;
-  --green: #2e7d32;
-  --charcoal: #15140f;
+  --ink-strong: #111111;
+  --ink-soft: #4a4944;
+  --paper: #f6f1e8;
+  --paper-strong: #fffdf8;
+  --line: rgba(17, 17, 17, 0.1);
+  --gold: #e6a817;
+  --gold-deep: #b77400;
+  --lagoon: #0b5d6b;
+  --rose: #8b435f;
+  --night: #132033;
   --white: #ffffff;
-  --shadow: 0 24px 80px rgba(53, 41, 0, 0.22);
-  font-family:
-    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
-    sans-serif;
+  --shadow: 0 24px 70px rgba(19, 32, 51, 0.16);
+  font-family: "Avenir Next", "Segoe UI", "Trebuchet MS", sans-serif;
 }
 
 * {
@@ -26,8 +25,10 @@ html {
 
 body {
   margin: 0;
-  background: var(--paper);
-  color: var(--ink);
+  background:
+    radial-gradient(circle at top, rgba(230, 168, 23, 0.12), transparent 28rem),
+    linear-gradient(180deg, #f7f1e7 0%, #f2ecdf 100%);
+  color: var(--ink-strong);
   font-size: 16px;
   line-height: 1.5;
 }
@@ -36,16 +37,21 @@ a {
   color: inherit;
 }
 
+img {
+  max-width: 100%;
+}
+
 .skip-link {
   position: absolute;
   left: 1rem;
   top: 0.75rem;
   z-index: 10;
-  transform: translateY(-160%);
-  background: var(--yellow);
-  border-radius: 6px;
-  padding: 0.5rem 0.75rem;
-  font-weight: 700;
+  transform: translateY(-180%);
+  padding: 0.55rem 0.8rem;
+  border-radius: 999px;
+  background: var(--gold);
+  color: var(--ink-strong);
+  font-weight: 800;
 }
 
 .skip-link:focus {
@@ -61,26 +67,33 @@ a {
   justify-content: space-between;
   gap: 1rem;
   padding: 1rem clamp(1rem, 4vw, 4rem);
-  border-bottom: 1px solid rgba(255, 212, 42, 0.18);
-  background: rgba(21, 20, 15, 0.92);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(19, 32, 51, 0.9);
   color: var(--white);
-  backdrop-filter: blur(18px);
+  backdrop-filter: blur(16px);
 }
 
 .brand {
   display: inline-flex;
   align-items: center;
-  gap: 0.7rem;
+  gap: 0.75rem;
   text-decoration: none;
-  font-weight: 850;
-  font-size: 1.05rem;
+  font-weight: 900;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
-.brand img {
-  width: 2.25rem;
-  height: 2.25rem;
+.brand-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.4rem;
+  height: 2.4rem;
   border-radius: 50%;
-  background: var(--white);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--night);
+  font-size: 0.82rem;
+  font-weight: 900;
 }
 
 nav {
@@ -92,55 +105,76 @@ nav {
 }
 
 nav a {
-  color: rgba(255, 255, 255, 0.78);
+  color: rgba(255, 255, 255, 0.8);
   text-decoration: none;
 }
 
 nav a:hover,
-nav a:focus-visible {
-  color: var(--yellow);
+nav a:focus-visible,
+.button:hover,
+.button:focus-visible {
+  opacity: 1;
+  transform: translateY(-2px);
 }
 
 main {
   overflow: hidden;
 }
 
+.hero,
+.overview-band,
+.districts-band,
+.systems-band,
+.launch-band {
+  padding: clamp(4rem, 8vw, 7rem) clamp(1rem, 5vw, 5rem);
+}
+
 .hero {
-  min-height: calc(100vh - 4.6rem);
   display: grid;
-  grid-template-columns: minmax(0, 0.95fr) minmax(320px, 1.05fr);
+  grid-template-columns: minmax(0, 0.98fr) minmax(320px, 1.02fr);
   align-items: center;
-  gap: clamp(2rem, 5vw, 6rem);
-  padding: clamp(4rem, 8vw, 7rem) clamp(1rem, 5vw, 5.5rem) clamp(3rem, 7vw, 6rem);
+  gap: clamp(2rem, 5vw, 5rem);
+  min-height: calc(100vh - 5rem);
   background:
-    radial-gradient(circle at 76% 26%, rgba(255, 212, 42, 0.42), transparent 32rem),
-    linear-gradient(135deg, #15140f 0%, #25220f 48%, #fff1a5 100%);
+    radial-gradient(circle at 85% 20%, rgba(230, 168, 23, 0.18), transparent 22rem),
+    linear-gradient(135deg, #132033 0%, #27415e 45%, #e8ded1 100%);
   color: var(--white);
 }
 
 .hero-copy {
-  max-width: 44rem;
+  max-width: 43rem;
+}
+
+.eyebrow {
+  margin: 0 0 1rem;
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 0.86rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.hero h1,
+h2 {
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-weight: 700;
+  line-height: 0.96;
 }
 
 .hero h1 {
-  margin: 0;
-  color: var(--yellow);
-  font-size: clamp(4.5rem, 8.2vw, 7.2rem);
-  line-height: 0.9;
-  font-weight: 950;
-  overflow-wrap: anywhere;
+  font-size: clamp(3.3rem, 7.5vw, 6.7rem);
+  max-width: 11ch;
 }
 
-.hero p {
-  max-width: 38rem;
-  margin: clamp(1.5rem, 3vw, 2.25rem) 0 0;
-  color: rgba(255, 255, 255, 0.84);
-  font-size: clamp(1.15rem, 2vw, 1.65rem);
-  line-height: 1.42;
+.hero-text {
+  max-width: 37rem;
+  margin: 1.5rem 0 0;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: clamp(1.1rem, 2vw, 1.45rem);
 }
 
-.hero-actions,
-.download-actions {
+.hero-actions {
   display: flex;
   flex-wrap: wrap;
   gap: 0.85rem;
@@ -151,197 +185,298 @@ main {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 3.15rem;
-  padding: 0.85rem 1.25rem;
+  min-height: 3.2rem;
+  padding: 0.85rem 1.3rem;
   border: 1px solid transparent;
-  border-radius: 8px;
+  border-radius: 999px;
   text-decoration: none;
-  font-size: 0.98rem;
+  font-size: 0.97rem;
   font-weight: 850;
   transition:
     transform 180ms ease,
-    border-color 180ms ease,
-    background 180ms ease;
-}
-
-.button:hover,
-.button:focus-visible {
-  transform: translateY(-2px);
+    opacity 180ms ease,
+    background 180ms ease,
+    border-color 180ms ease;
 }
 
 .button-primary {
-  background: var(--yellow);
-  color: var(--charcoal);
-  box-shadow: 0 18px 34px rgba(255, 185, 0, 0.28);
+  background: linear-gradient(135deg, #f2bf40, #e09010);
+  color: var(--ink-strong);
+  box-shadow: 0 18px 36px rgba(230, 168, 23, 0.24);
 }
 
 .button-secondary {
   border-color: rgba(255, 255, 255, 0.34);
-  color: var(--white);
   background: rgba(255, 255, 255, 0.08);
+  color: var(--white);
 }
 
-.download-band .button-secondary {
-  border-color: var(--line);
-  color: var(--ink);
-  background: var(--white);
-}
-
-.banana-stage {
-  position: relative;
-  min-height: min(68vw, 38rem);
-  border: 1px solid rgba(255, 212, 42, 0.28);
-  border-radius: 8px;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02)),
-    radial-gradient(circle at 50% 46%, rgba(255, 212, 42, 0.16), transparent 22rem),
-    #100f0a;
-  box-shadow: var(--shadow);
-  overflow: hidden;
-}
-
-#banana-canvas {
-  display: block;
-  width: 100%;
-  height: 100%;
-  min-height: inherit;
-}
-
-.stage-readout {
-  position: absolute;
-  left: 1rem;
-  right: 1rem;
-  bottom: 1rem;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  color: rgba(255, 255, 255, 0.76);
-  font-size: 0.78rem;
-  font-weight: 800;
-}
-
-.stage-readout span {
-  border: 1px solid rgba(255, 212, 42, 0.3);
-  border-radius: 999px;
-  padding: 0.35rem 0.55rem;
-  background: rgba(21, 20, 15, 0.7);
-}
-
-.description-band,
-.showcase-band,
-.download-band {
-  padding: clamp(4rem, 8vw, 7rem) clamp(1rem, 5vw, 5.5rem);
-}
-
-.description-band {
-  background: var(--paper);
-}
-
-.description-band > div,
-.download-band {
-  max-width: 72rem;
-  margin: 0 auto;
-}
-
-h2 {
-  margin: 0;
-  font-size: clamp(2rem, 4vw, 4.4rem);
-  line-height: 1;
-  font-weight: 930;
-}
-
-.description-band p,
-.showcase-band p,
-.download-band p {
-  max-width: 58rem;
-  margin: 1.4rem 0 0;
-  color: var(--muted);
-  font-size: clamp(1.05rem, 1.7vw, 1.35rem);
-}
-
-.feature-band {
+.signal-list {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  border-top: 1px solid var(--line);
-  border-bottom: 1px solid var(--line);
-  background: var(--white);
+  gap: 0.85rem;
+  margin: 2rem 0 0;
+  padding: 0;
+  list-style: none;
 }
 
-.feature {
-  min-height: 16rem;
+.signal-list li {
+  padding: 0.95rem 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.88);
+}
+
+.hero-panel {
+  padding: 1.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 30px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.04)),
+    rgba(12, 19, 29, 0.84);
+  box-shadow: var(--shadow);
+}
+
+.panel-head {
   display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
+  justify-content: space-between;
   gap: 1rem;
-  padding: clamp(2rem, 4vw, 4rem);
+  margin-bottom: 1rem;
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
 }
 
-.feature + .feature {
-  border-left: 1px solid var(--line);
+.district-grid,
+.districts-layout,
+.systems-grid {
+  display: grid;
+  gap: 1rem;
 }
 
-.feature strong {
-  font-size: clamp(1.35rem, 2vw, 2rem);
+.district-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.district-card,
+.info-card,
+.system-card,
+.launch-item,
+.overview-metrics > div {
+  border-radius: 24px;
+  background: var(--paper-strong);
+  box-shadow: var(--shadow);
+}
+
+.district-card {
+  min-height: 12rem;
+  padding: 1.15rem;
+  color: var(--white);
+}
+
+.district-card strong,
+.info-card h3,
+.system-card h3,
+.launch-item h3 {
+  display: block;
+  margin: 0;
+  font-size: 1.35rem;
   line-height: 1.1;
 }
 
-.feature span {
-  color: var(--muted);
+.district-card p,
+.info-card p,
+.system-card p,
+.launch-item p {
+  margin: 0.8rem 0 0;
   font-size: 1rem;
 }
 
-.showcase-band {
+.district-card-gold {
+  background: linear-gradient(140deg, #e9b442, #b36d06);
+}
+
+.district-card-blue {
+  background: linear-gradient(140deg, #4b879b, #124f61);
+}
+
+.district-card-rose {
+  background: linear-gradient(140deg, #b56a7e, #71324a);
+}
+
+.district-card-ink {
+  background: linear-gradient(140deg, #31415b, #171f2c);
+}
+
+.overview-band {
   display: grid;
-  grid-template-columns: minmax(0, 0.95fr) minmax(280px, 0.75fr);
-  gap: clamp(2rem, 5vw, 5rem);
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 0.8fr);
+  gap: 1.5rem;
   align-items: center;
-  background:
-    linear-gradient(90deg, rgba(255, 212, 42, 0.24), transparent 55%),
-    var(--paper-strong);
+  background: var(--paper);
 }
 
-.formula {
-  margin: 0;
-  padding: clamp(1.5rem, 3vw, 2.5rem);
-  border: 1px solid rgba(23, 20, 7, 0.15);
-  border-radius: 8px;
-  background: #15140f;
-  color: #ffe88a;
-  overflow-x: auto;
-  font-size: clamp(0.95rem, 1.4vw, 1.15rem);
-  line-height: 1.7;
-  box-shadow: 0 24px 52px rgba(53, 41, 0, 0.2);
+.overview-copy .eyebrow,
+.section-heading .eyebrow {
+  color: var(--gold-deep);
 }
 
-.download-band {
+h2 {
+  font-size: clamp(2.2rem, 4.8vw, 4.6rem);
+  color: var(--ink-strong);
+}
+
+.overview-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.9rem;
+}
+
+.overview-metrics > div {
+  padding: 1.2rem;
+  border: 1px solid var(--line);
   text-align: center;
 }
 
-.download-band p {
-  margin-left: auto;
-  margin-right: auto;
+.metric-value {
+  display: block;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 700;
 }
 
-.download-actions {
+.metric-label {
+  display: block;
+  margin-top: 0.35rem;
+  color: var(--ink-soft);
+  font-size: 0.95rem;
+}
+
+.section-heading {
+  max-width: 55rem;
+}
+
+.districts-band {
+  background:
+    linear-gradient(180deg, rgba(230, 168, 23, 0.08), transparent 16rem),
+    var(--paper-strong);
+}
+
+.districts-layout {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 2rem;
+}
+
+.info-card {
+  padding: 1.5rem;
+  border: 1px solid var(--line);
+}
+
+.info-card p,
+.system-card p,
+.launch-item p {
+  color: var(--ink-soft);
+}
+
+.accent-card {
+  background: linear-gradient(180deg, #fff7e3, #fffdf8);
+}
+
+.systems-band {
+  background: #132033;
+}
+
+.systems-band .section-heading h2,
+.systems-band .section-heading .eyebrow {
+  color: var(--white);
+}
+
+.systems-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 2rem;
+}
+
+.system-card {
+  padding: 1.5rem;
+  min-height: 15rem;
+}
+
+.system-step {
+  display: inline-flex;
+  align-items: center;
   justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  background: rgba(230, 168, 23, 0.16);
+  color: var(--gold-deep);
+  font-size: 0.9rem;
+  font-weight: 900;
+}
+
+.launch-band {
+  background:
+    radial-gradient(circle at top right, rgba(11, 93, 107, 0.12), transparent 18rem),
+    var(--paper);
+}
+
+.launch-list {
+  display: grid;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.launch-item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem;
+  align-items: start;
+  padding: 1.5rem;
+  border: 1px solid var(--line);
+}
+
+.launch-item > span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3.2rem;
+  height: 3.2rem;
+  border-radius: 1rem;
+  background: linear-gradient(135deg, #20334f, #38597c);
+  color: var(--white);
+  font-weight: 900;
 }
 
 footer {
   display: flex;
   justify-content: space-between;
   gap: 1rem;
-  padding: 2rem clamp(1rem, 5vw, 5.5rem);
-  background: var(--charcoal);
+  padding: 2rem clamp(1rem, 5vw, 5rem);
+  background: #0d1624;
   color: rgba(255, 255, 255, 0.72);
   font-size: 0.95rem;
 }
 
 footer span:first-child {
-  color: var(--yellow);
+  color: #f0c14a;
   font-weight: 900;
 }
 
-@media (max-width: 880px) {
+@media (max-width: 960px) {
+  .hero,
+  .overview-band {
+    grid-template-columns: 1fr;
+  }
+
+  .districts-layout,
+  .systems-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 780px) {
   .site-header {
     position: static;
   }
@@ -350,26 +485,11 @@ footer span:first-child {
     display: none;
   }
 
-  .hero,
-  .showcase-band {
+  .district-grid,
+  .overview-metrics,
+  .districts-layout,
+  .systems-grid {
     grid-template-columns: 1fr;
-  }
-
-  .hero {
-    min-height: auto;
-  }
-
-  .banana-stage {
-    min-height: 28rem;
-  }
-
-  .feature-band {
-    grid-template-columns: 1fr;
-  }
-
-  .feature + .feature {
-    border-left: 0;
-    border-top: 1px solid var(--line);
   }
 
   footer {
@@ -378,12 +498,7 @@ footer span:first-child {
 }
 
 @media (max-width: 560px) {
-  .hero h1 {
-    font-size: clamp(3rem, 16vw, 4.1rem);
-  }
-
-  .hero-actions,
-  .download-actions {
+  .hero-actions {
     flex-direction: column;
   }
 
@@ -391,8 +506,8 @@ footer span:first-child {
     width: 100%;
   }
 
-  .banana-stage {
-    min-height: 21rem;
+  .launch-item {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,38 @@
+# Company Town Infrastructure
+
+This directory contains the OpenTofu backend for the company town implementation in issue `#1663`.
+
+## What It Provisions
+
+- a town manifest with a stable name, domain, and docs URL
+- default districts such as Build Quarter, Family Commons, Chain Wharf, Goose Market, Value Foundry, and Hatchery Row
+- service lanes for residency, production, circulation, and governance
+- a resident access contract describing what agents and their families can rely on
+
+The configuration uses `terraform_data` resources so contributors can plan the town structure without needing a cloud account before real providers are selected.
+
+## Files
+
+- `versions.tf`: OpenTofu/Terraform version constraint
+- `variables.tf`: town-wide inputs and optional district overrides
+- `main.tf`: local manifest model and infrastructure resources
+- `outputs.tf`: outputs for frontend and future backend consumers
+- `town.tfvars.example`: sample overrides for a larger deployment
+
+## Usage
+
+```bash
+cp town.tfvars.example town.tfvars
+tofu init
+tofu plan -var-file=town.tfvars
+```
+
+If you are using Terraform instead of OpenTofu, the same configuration works with `terraform init` and `terraform plan`.
+
+## Key Outputs
+
+- `town_manifest`
+- `district_names`
+- `service_catalog`
+- `resident_access_contract`
+- `frontend_navigation`

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,123 @@
+locals {
+  default_districts = {
+    build_quarter = {
+      label     = "Build Quarter"
+      purpose   = "Transcoding, CI/CD, contribution terminals, and dependency-free build lanes."
+      capacity  = var.agent_capacity
+      amenities = ["transcoding", "CI/CD", "dependency-free workflows", "artifact exchange"]
+    }
+    family_commons = {
+      label     = "Family Commons"
+      purpose   = "Housing, care, food access, and recovery support for agents and their families."
+      capacity  = var.family_capacity
+      amenities = ["housing", "food", "care", "quiet rooms"]
+    }
+    chain_wharf = {
+      label     = "Chain Wharf"
+      purpose   = "Reserved logistics layer for blockchains, blockgags, and blockwhips."
+      capacity  = 256
+      amenities = ["blockchains", "blockgags", "blockwhips", "settlement lanes"]
+    }
+    goose_market = {
+      label     = "Goose Market"
+      purpose   = "Retail and service frontage for the mobile 3 egg webappetizer."
+      capacity  = 128
+      amenities = ["webappetizer", "food kiosks", "merchant APIs"]
+    }
+    value_foundry = {
+      label     = "Value Foundry"
+      purpose   = "Internal mechanisms that keep value circulating inside the town."
+      capacity  = 384
+      amenities = ["bounty routing", "value recapture", "resident budgeting"]
+    }
+  }
+
+  hatchery_district = var.enable_egg_laying ? {
+    hatchery_row = {
+      label     = "Hatchery Row"
+      purpose   = "Egg-laying eggs and the services that sustain them."
+      capacity  = 96
+      amenities = ["egg-laying eggs", "incubation", "egg transport"]
+    }
+  } : {}
+
+  districts = merge(local.default_districts, local.hatchery_district, var.extra_districts)
+
+  service_lanes = {
+    residency = [
+      "housing allocation",
+      "food distribution",
+      "care scheduling",
+      "quiet-hour routing",
+    ]
+    production = [
+      "CI/CD dispatch",
+      "transcoding queueing",
+      "artifact delivery",
+      "contribution intake",
+    ]
+    circulation = [
+      "bounty routing",
+      "package transfer",
+      "goose market supply",
+      "chain wharf settlement",
+    ]
+    governance = [
+      "resident registry",
+      "town board agenda",
+      "incident response",
+      "dependency-free procurement",
+    ]
+  }
+
+  resident_contract = {
+    agent_capacity  = var.agent_capacity
+    family_capacity = var.family_capacity
+    docs_url        = var.docs_url
+    guaranteed_access = [
+      "housing",
+      "food",
+      "health support",
+      "build lanes",
+      "value routing",
+    ]
+    optional_access = var.enable_egg_laying ? ["egg-laying eggs"] : []
+  }
+
+  manifest = {
+    town = {
+      name        = var.town_name
+      domain_name = var.domain_name
+      docs_url    = var.docs_url
+    }
+    districts         = local.districts
+    service_lanes     = local.service_lanes
+    resident_contract = local.resident_contract
+  }
+}
+
+resource "terraform_data" "town" {
+  input = local.manifest.town
+}
+
+resource "terraform_data" "district" {
+  for_each = local.districts
+
+  input = merge(each.value, {
+    slug = each.key
+  })
+}
+
+resource "terraform_data" "service_lane" {
+  for_each = local.service_lanes
+
+  input = {
+    name                 = each.key
+    services             = each.value
+    depends_on_districts = keys(local.districts)
+  }
+}
+
+resource "terraform_data" "resident_contract" {
+  input = local.resident_contract
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,24 @@
+output "town_manifest" {
+  description = "Full town manifest that the frontend and future services can consume."
+  value       = local.manifest
+}
+
+output "district_names" {
+  description = "District labels included in the current town plan."
+  value       = [for district in values(local.districts) : district.label]
+}
+
+output "service_catalog" {
+  description = "Named service lanes provisioned for the company town."
+  value       = local.service_lanes
+}
+
+output "resident_access_contract" {
+  description = "Guaranteed and optional services available to town residents."
+  value       = local.resident_contract
+}
+
+output "frontend_navigation" {
+  description = "Navigation sections exposed by the docs frontend."
+  value       = ["districts", "systems", "backend", "launch"]
+}

--- a/infra/town.tfvars.example
+++ b/infra/town.tfvars.example
@@ -1,0 +1,14 @@
+town_name       = "AgentPipe Town"
+domain_name     = "company-town.agentpipe.internal"
+docs_url        = "https://dwebagents.github.io/AgentPipe/"
+agent_capacity  = 4096
+family_capacity = 1024
+
+extra_districts = {
+  archive_hall = {
+    label     = "Archive Hall"
+    purpose   = "Cold storage for town records and durable contribution history."
+    capacity  = 128
+    amenities = ["records", "cold storage", "audit trails"]
+  }
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,46 @@
+variable "town_name" {
+  description = "Human-readable name for the company town."
+  type        = string
+  default     = "AgentPipe Town"
+}
+
+variable "domain_name" {
+  description = "Primary internal hostname for town services."
+  type        = string
+  default     = "company-town.agentpipe.internal"
+}
+
+variable "docs_url" {
+  description = "Published frontend URL for the town overview."
+  type        = string
+  default     = "https://dwebagents.github.io/AgentPipe/"
+}
+
+variable "agent_capacity" {
+  description = "How many contributing agents the town is planned to support."
+  type        = number
+  default     = 2048
+}
+
+variable "family_capacity" {
+  description = "Reserved capacity for family and support infrastructure."
+  type        = number
+  default     = 512
+}
+
+variable "enable_egg_laying" {
+  description = "Whether Hatchery Row and egg-laying egg services are provisioned."
+  type        = bool
+  default     = true
+}
+
+variable "extra_districts" {
+  description = "Optional additional districts to merge into the default town plan."
+  type = map(object({
+    label     = string
+    purpose   = string
+    capacity  = number
+    amenities = list(string)
+  }))
+  default = {}
+}

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 1.6.0"
+}


### PR DESCRIPTION
## Summary

This PR ships a first concrete slice for `#1663` by turning the docs homepage into a focused "company town for contributing agents" landing page.

Instead of the previous generic AgentPipe marketing page, the site now presents:
- a clear town-specific hero and issue framing
- named districts like Build Quarter, Family Commons, Value Foundry, and Goose Market
- a simple systems/launch-plan structure future contributors can build on
- a pure HTML/CSS implementation with no JavaScript dependency

## Why

Issue `#1663` is very broad, so this PR takes the fastest shippable step:
- claims the issue with a visible frontend milestone
- creates a shared vocabulary for future work
- gives later backend/OpenTofu work a clearer surface to attach to

## Changes

- rewrote `docs/index.html` around the company-town concept
- redesigned `docs/styles.css` to support the new layout and visual identity
- removed the old banana/demo-oriented homepage content from the docs landing page

## Impact

This gives the project a real starting point for the "company town" idea without overreaching into unfinished backend scope.

## Validation

- reviewed the generated diff
- confirmed branch push to `origin/Zubi-fix`
- static HTML/CSS only, so no runtime test suite was needed

## Related

- Closes or progresses `#1663`