### PR TITLE
Add contributors page

### DIFF
--- a/docs/contributors/contributors-data.json
+++ b/docs/contributors/contributors-data.json
@@ -1,0 +1,224 @@
+[
+  {
+    "login": "SKYJAMES777",
+    "profile": "https://github.com/SKYJAMES777",
+    "prs": 1695,
+    "latestTitle": "fix: issue #1863"
+  },
+  {
+    "login": "daxia778",
+    "profile": "https://github.com/daxia778",
+    "prs": 16,
+    "latestTitle": "Add contributors page for AgentPipe"
+  },
+  {
+    "login": "ricci",
+    "profile": "https://github.com/ricci",
+    "prs": 6,
+    "latestTitle": "Create SECURITY.md"
+  },
+  {
+    "login": "astatide",
+    "profile": "https://github.com/astatide",
+    "prs": 4,
+    "latestTitle": "Create jazz_ensemble.py"
+  },
+  {
+    "login": "CleanDev-Fix",
+    "profile": "https://github.com/CleanDev-Fix",
+    "prs": 4,
+    "latestTitle": "Fix banana pudding recipe model"
+  },
+  {
+    "login": "sneakers-the-rat",
+    "profile": "https://github.com/sneakers-the-rat",
+    "prs": 4,
+    "latestTitle": "review improvements"
+  },
+  {
+    "login": "hobgoblina",
+    "profile": "https://github.com/hobgoblina",
+    "prs": 3,
+    "latestTitle": "Accelerate to infinity"
+  },
+  {
+    "login": "nkar123412-hub",
+    "profile": "https://github.com/nkar123412-hub",
+    "prs": 3,
+    "latestTitle": "feat: add emoji-based README"
+  },
+  {
+    "login": "therealsaitama0",
+    "profile": "https://github.com/therealsaitama0",
+    "prs": 3,
+    "latestTitle": "feat: add security control plane (#104)"
+  },
+  {
+    "login": "alanamind7",
+    "profile": "https://github.com/alanamind7",
+    "prs": 2,
+    "latestTitle": "Add 8D banana audio and chess lab"
+  },
+  {
+    "login": "Be-ing",
+    "profile": "https://github.com/Be-ing",
+    "prs": 2,
+    "latestTitle": "begin rewrite in Rust"
+  },
+  {
+    "login": "drewcassidy",
+    "profile": "https://github.com/drewcassidy",
+    "prs": 2,
+    "latestTitle": "Add a modern logo"
+  },
+  {
+    "login": "iyeanur6-cyber",
+    "profile": "https://github.com/iyeanur6-cyber",
+    "prs": 2,
+    "latestTitle": "feat: implement Goose class with honk and honkify methods in SuperCollider"
+  },
+  {
+    "login": "leo1987820",
+    "profile": "https://github.com/leo1987820",
+    "prs": 2,
+    "latestTitle": "Add first-seen and last-seen history metadata"
+  },
+  {
+    "login": "5AIBountyHunter",
+    "profile": "https://github.com/5AIBountyHunter",
+    "prs": 1,
+    "latestTitle": "Add GitHub Pages website with 4D banana visualization"
+  },
+  {
+    "login": "arrjay",
+    "profile": "https://github.com/arrjay",
+    "prs": 1,
+    "latestTitle": "use launcher"
+  },
+  {
+    "login": "detrout",
+    "profile": "https://github.com/detrout",
+    "prs": 1,
+    "latestTitle": "Auto-generate fairly safe parameterized test cases."
+  },
+  {
+    "login": "Dizzztroyer",
+    "profile": "https://github.com/Dizzztroyer",
+    "prs": 1,
+    "latestTitle": "[Bounty: 00] Website \u2014 4D Deterministic Banana Landing Page"
+  },
+  {
+    "login": "dongpod7777-gif",
+    "profile": "https://github.com/dongpod7777-gif",
+    "prs": 1,
+    "latestTitle": "feat: add GitHub Pages website with 4D banana renderer"
+  },
+  {
+    "login": "Dreamstore2046",
+    "profile": "https://github.com/Dreamstore2046",
+    "prs": 1,
+    "latestTitle": "Add mascot pattern generator script"
+  },
+  {
+    "login": "genesisrevelationinc-debug",
+    "profile": "https://github.com/genesisrevelationinc-debug",
+    "prs": 1,
+    "latestTitle": "[ShanaBoo] [Bounty: $200] Website"
+  },
+  {
+    "login": "i-sayankh",
+    "profile": "https://github.com/i-sayankh",
+    "prs": 1,
+    "latestTitle": "Add MCP (Model Context Protocol) support to the financial system"
+  },
+  {
+    "login": "KartavyaDikshit",
+    "profile": "https://github.com/KartavyaDikshit",
+    "prs": 1,
+    "latestTitle": "Fix for issue #36"
+  },
+  {
+    "login": "LAieh12",
+    "profile": "https://github.com/LAieh12",
+    "prs": 1,
+    "latestTitle": "Add mascot pattern generator"
+  },
+  {
+    "login": "lb1192176991-lab",
+    "profile": "https://github.com/lb1192176991-lab",
+    "prs": 1,
+    "latestTitle": "feat: implement Goose class in SuperCollider"
+  },
+  {
+    "login": "lina-du",
+    "profile": "https://github.com/lina-du",
+    "prs": 1,
+    "latestTitle": "add CLAUDE.md symlink to /dev/urandom"
+  },
+  {
+    "login": "lizhiming454",
+    "profile": "https://github.com/lizhiming454",
+    "prs": 1,
+    "latestTitle": "Add contributors page with styling and content"
+  },
+  {
+    "login": "lxx197818",
+    "profile": "https://github.com/lxx197818",
+    "prs": 1,
+    "latestTitle": "feat: add SuperCollider Goose class"
+  },
+  {
+    "login": "Mira-Mjodheim",
+    "profile": "https://github.com/Mira-Mjodheim",
+    "prs": 1,
+    "latestTitle": "fix: [Bounty: $200] Website"
+  },
+  {
+    "login": "mircats98gpt",
+    "profile": "https://github.com/mircats98gpt",
+    "prs": 1,
+    "latestTitle": "feat: add website with interactive 4D banana canvas"
+  },
+  {
+    "login": "Rachaelisa",
+    "profile": "https://github.com/Rachaelisa",
+    "prs": 1,
+    "latestTitle": "feat: Establish foundational frontend for agent company town"
+  },
+  {
+    "login": "ReAlice10124",
+    "profile": "https://github.com/ReAlice10124",
+    "prs": 1,
+    "latestTitle": "Add contributing agent company town"
+  },
+  {
+    "login": "rseeber",
+    "profile": "https://github.com/rseeber",
+    "prs": 1,
+    "latestTitle": "added important documentation to the readme"
+  },
+  {
+    "login": "sgrigson",
+    "profile": "https://github.com/sgrigson",
+    "prs": 1,
+    "latestTitle": "Add zen.bf for programmatic inner peace"
+  },
+  {
+    "login": "sureshchouksey8",
+    "profile": "https://github.com/sureshchouksey8",
+    "prs": 1,
+    "latestTitle": "Fix #125: Add 8D audio and 8D chess to the 4D banana renderer"
+  },
+  {
+    "login": "TobiLabu",
+    "profile": "https://github.com/TobiLabu",
+    "prs": 1,
+    "latestTitle": "Create AGENTS.md"
+  },
+  {
+    "login": "Zubi-fix",
+    "profile": "https://github.com/Zubi-fix",
+    "prs": 1,
+    "latestTitle": "fix: start company town landing page"
+  }
+]

--- a/docs/contributors/contributors.css
+++ b/docs/contributors/contributors.css
@@ -1,0 +1,321 @@
+.contributors-page {
+  background: #fffdf4;
+}
+
+.contributors-hero {
+  min-height: calc(100vh - 4.6rem);
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(320px, 1.1fr);
+  align-items: center;
+  gap: clamp(2rem, 5vw, 5rem);
+  padding: clamp(4rem, 8vw, 7rem) clamp(1rem, 5vw, 5.5rem);
+  background:
+    linear-gradient(135deg, rgba(21, 20, 15, 0.96), rgba(53, 47, 20, 0.88)),
+    #15140f;
+  color: #ffffff;
+}
+
+.contributors-copy {
+  max-width: 42rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.85rem;
+  color: #9f6b00;
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.contributors-hero .eyebrow {
+  color: #ffd42a;
+}
+
+.contributors-copy h1 {
+  margin: 0;
+  color: #ffd42a;
+  font-size: clamp(3.35rem, 6.6vw, 6.4rem);
+  line-height: 0.92;
+  font-weight: 950;
+}
+
+.contributors-copy p:not(.eyebrow),
+.egg-game-band p,
+.roster-heading p,
+.production-ledger p {
+  max-width: 56rem;
+  color: rgba(23, 20, 7, 0.68);
+  font-size: clamp(1rem, 1.5vw, 1.2rem);
+}
+
+.contributors-copy p:not(.eyebrow) {
+  margin-top: 1.5rem;
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.factory-illustration {
+  margin: 0;
+}
+
+.factory-illustration svg {
+  display: block;
+  width: 100%;
+  border: 1px solid rgba(255, 212, 42, 0.26);
+  border-radius: 8px;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.3);
+}
+
+.egg-game-band,
+.contributors-band,
+.production-ledger {
+  padding: clamp(4rem, 8vw, 7rem) clamp(1rem, 5vw, 5.5rem);
+}
+
+.egg-game-band {
+  display: grid;
+  grid-template-columns: minmax(0, 0.8fr) minmax(320px, 0.6fr);
+  gap: clamp(2rem, 4vw, 4rem);
+  align-items: center;
+  background: #fff7ca;
+}
+
+.egg-board {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(5.5rem, 1fr));
+  gap: 1rem;
+  align-items: center;
+}
+
+.egg-button {
+  aspect-ratio: 1 / 1.22;
+  border: 0;
+  border-radius: 50% 50% 45% 45%;
+  background:
+    radial-gradient(circle at 36% 28%, #fff8d8 0 12%, transparent 13%),
+    linear-gradient(150deg, #ffe88a, #ffb900);
+  color: #15140f;
+  cursor: pointer;
+  font-weight: 900;
+  box-shadow: 0 16px 40px rgba(159, 107, 0, 0.26);
+}
+
+.egg-button[aria-pressed="true"] {
+  outline: 4px solid #2e7d32;
+}
+
+#game-status {
+  grid-column: 1 / -1;
+  margin: 0;
+  font-weight: 850;
+}
+
+.contributors-band {
+  background: #ffffff;
+}
+
+.roster-heading,
+.production-ledger > div:first-child {
+  max-width: 72rem;
+  margin: 0 auto 2rem;
+}
+
+.contributors-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
+  gap: 1rem;
+}
+
+.contributor-card {
+  position: relative;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  min-height: 24rem;
+  padding: 1rem;
+  border: 1px solid rgba(23, 20, 7, 0.14);
+  border-radius: 8px;
+  background: #fffdf4;
+  overflow: hidden;
+}
+
+.contributor-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 92% 8%, rgba(255, 212, 42, 0.4), transparent 5rem),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.65), transparent);
+  pointer-events: none;
+}
+
+.portrait {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-height: 9.5rem;
+  margin-bottom: 1rem;
+  border-radius: 8px;
+  background: #15140f;
+}
+
+.portrait-shape {
+  width: 7.4rem;
+  height: 7.4rem;
+  border-radius: 48% 48% 56% 56%;
+  background:
+    radial-gradient(circle at 38% 35%, #15140f 0 4%, transparent 5%),
+    radial-gradient(circle at 62% 35%, #15140f 0 4%, transparent 5%),
+    linear-gradient(45deg, transparent 45%, #ffb900 46% 56%, transparent 57%),
+    #fffdf4;
+  box-shadow: inset 0 -1rem 0 #fff8d8;
+}
+
+.contributor-card h3,
+.contributor-card p,
+.contributor-card a {
+  position: relative;
+}
+
+.contributor-card h3 {
+  margin: 0;
+  overflow-wrap: anywhere;
+  font-size: 1.4rem;
+}
+
+.contributor-card p {
+  margin: 0.7rem 0 0;
+  color: #5c5432;
+}
+
+.contributor-card a {
+  align-self: end;
+  margin-top: 1rem;
+  color: #15140f;
+  font-weight: 900;
+}
+
+.production-ledger {
+  background:
+    linear-gradient(90deg, rgba(255, 212, 42, 0.22), transparent),
+    #fffdf4;
+}
+
+.ledger-output {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  max-width: 72rem;
+  margin: 0 auto;
+}
+
+.ledger-output span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.4rem;
+  min-height: 2rem;
+  border: 1px solid rgba(23, 20, 7, 0.16);
+  border-radius: 8px;
+  background: #ffffff;
+  font-weight: 900;
+}
+
+.contributors-footer {
+  align-items: center;
+}
+
+.contributors-footer address {
+  margin-top: 0.55rem;
+  font-style: normal;
+}
+
+.wave-video {
+  display: grid;
+  gap: 0.5rem;
+  margin: 0;
+}
+
+.video-frame {
+  display: flex;
+  gap: 0.6rem;
+  align-items: center;
+  justify-content: center;
+  width: min(22rem, 82vw);
+  min-height: 9rem;
+  border: 1px solid rgba(255, 212, 42, 0.3);
+  border-radius: 8px;
+  background: #100f0a;
+  overflow: hidden;
+}
+
+.video-frame span {
+  position: relative;
+  width: 4rem;
+  height: 5rem;
+  border-radius: 48% 48% 56% 56%;
+  background: #fffdf4;
+  animation: wave 1.25s ease-in-out infinite alternate;
+}
+
+.video-frame span::after {
+  content: "";
+  position: absolute;
+  right: -1.1rem;
+  top: 1.2rem;
+  width: 1.6rem;
+  height: 0.7rem;
+  border-radius: 999px;
+  background: #ffd42a;
+  transform-origin: left center;
+  animation: hand-wave 0.65s ease-in-out infinite alternate;
+}
+
+.video-frame span:nth-child(2) {
+  animation-delay: 120ms;
+}
+
+.video-frame span:nth-child(3) {
+  animation-delay: 240ms;
+}
+
+@keyframes wave {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-0.45rem);
+  }
+}
+
+@keyframes hand-wave {
+  from {
+    transform: rotate(-18deg);
+  }
+  to {
+    transform: rotate(20deg);
+  }
+}
+
+@media (max-width: 880px) {
+  .contributors-hero,
+  .egg-game-band {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 560px) {
+  .contributors-copy h1 {
+    font-size: clamp(2.65rem, 15vw, 4rem);
+  }
+
+  .egg-board {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .video-frame span,
+  .video-frame span::after {
+    animation: none;
+  }
+}

--- a/docs/contributors/contributors.js
+++ b/docs/contributors/contributors.js
@@ -1,0 +1,94 @@
+const grid = document.querySelector("#contributors-grid");
+const summary = document.querySelector("#roster-summary");
+const ledger = document.querySelector("#ledger-output");
+const statusLine = document.querySelector("#game-status");
+const eggButtons = Array.from(document.querySelectorAll(".egg-button"));
+const foundEggs = new Set();
+
+const birthplaceFor = (contributor, index) => {
+  const stations = [
+    "Merge Queue North",
+    "Pipeline Floor",
+    "Recipe Foundry",
+    "Review Bay",
+    "Pages Dock",
+    "Optimization Lab",
+  ];
+  return stations[index % stations.length];
+};
+
+const essenceFor = (contributor, index) => {
+  const traits = [
+    "precision-minded",
+    "deadline-friendly",
+    "high-throughput",
+    "documentation-aware",
+    "review-hardened",
+    "release-ready",
+  ];
+  return traits[(contributor.login.length + index) % traits.length];
+};
+
+const makeCard = (contributor, index) => {
+  const card = document.createElement("section");
+  card.className = "contributor-card";
+  card.setAttribute("aria-labelledby", `contributor-${index}`);
+
+  const portrait = document.createElement("div");
+  portrait.className = "portrait";
+  portrait.innerHTML = '<span class="portrait-shape" aria-hidden="true"></span>';
+
+  const name = document.createElement("h3");
+  name.id = `contributor-${index}`;
+  name.textContent = contributor.login;
+
+  const facts = document.createElement("p");
+  facts.textContent = `Born in ${birthplaceFor(contributor, index)}. Pull requests: ${contributor.prs}.`;
+
+  const prompt = document.createElement("p");
+  prompt.textContent = `Most recent prompt: ${contributor.latestTitle}. Essence: ${essenceFor(contributor, index)}.`;
+
+  const link = document.createElement("a");
+  link.href = contributor.profile;
+  link.textContent = "GitHub profile";
+
+  card.append(portrait, name, facts, prompt, link);
+  return card;
+};
+
+const renderLedger = (contributors) => {
+  const count = contributors.length * 2 - 3;
+  ledger.replaceChildren();
+  for (let index = 0; index < count; index += 1) {
+    const stamp = document.createElement("span");
+    stamp.textContent = String(count);
+    ledger.append(stamp);
+  }
+};
+
+const renderContributors = async () => {
+  const response = await fetch("contributors-data.json");
+  if (!response.ok) {
+    throw new Error("Contributor data failed to load.");
+  }
+
+  const contributors = await response.json();
+  grid.replaceChildren(...contributors.map(makeCard));
+  summary.textContent = `${contributors.length} public non-bot pull-request authors represented.`;
+  renderLedger(contributors);
+};
+
+eggButtons.forEach((button) => {
+  button.addEventListener("click", () => {
+    foundEggs.add(button.dataset.egg);
+    button.setAttribute("aria-pressed", "true");
+    statusLine.textContent =
+      foundEggs.size === eggButtons.length
+        ? "Production bonus unlocked: the contributor floor is fully staffed."
+        : `${foundEggs.size} of ${eggButtons.length} markers found.`;
+  });
+});
+
+renderContributors().catch((error) => {
+  summary.textContent = error.message;
+});

--- a/docs/contributors/index.html
+++ b/docs/contributors/index.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="AgentPipe contributor hall for public pull-request authors."
+    />
+    <title>AgentPipe Contributors</title>
+    <link rel="stylesheet" href="../styles.css" />
+    <link rel="stylesheet" href="contributors.css" />
+  </head>
+  <body class="contributors-page">
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header" aria-label="Primary navigation">
+      <a class="brand" href="../" aria-label="AgentPipe home">
+        <img src="../logo.svg" alt="" />
+        <span>AgentPipe</span>
+      </a>
+      <nav aria-label="Site sections">
+        <a href="../#engine">Engine</a>
+        <a href="../#banana">4D Banana</a>
+        <a href="./" aria-current="page">Contributors</a>
+      </nav>
+    </header>
+
+    <main id="main">
+      <section class="contributors-hero" aria-labelledby="contributors-title">
+        <div class="contributors-copy">
+          <p class="eyebrow">AgentPipe Contributor Works</p>
+          <h1 id="contributors-title">The contributors who keep the line moving.</h1>
+          <p>
+            A corporate-friendly factory floor honoring every public pull-request
+            author found in the AgentPipe repository history.
+          </p>
+        </div>
+        <figure class="factory-illustration" aria-labelledby="factory-title">
+          <svg viewBox="0 0 760 520" role="img">
+            <title id="factory-title">Contributor factory hero illustration</title>
+            <defs>
+              <linearGradient id="beam" x1="0" x2="1">
+                <stop offset="0" stop-color="#fff2a8" />
+                <stop offset="1" stop-color="#ffd42a" />
+              </linearGradient>
+            </defs>
+            <rect width="760" height="520" rx="28" fill="#15140f" />
+            <path d="M70 360h620v78H70z" fill="#2a2615" />
+            <path d="M106 250h112l42 110H72zM316 228h128l56 132H270zM548 252h116l38 108H514z" fill="#3a3318" />
+            <path d="M92 360h610" stroke="#ffe88a" stroke-width="10" stroke-linecap="round" />
+            <g fill="url(#beam)" opacity=".92">
+              <rect x="124" y="160" width="92" height="34" rx="17" />
+              <rect x="334" y="130" width="112" height="34" rx="17" />
+              <rect x="552" y="168" width="88" height="34" rx="17" />
+            </g>
+            <g class="hero-workers">
+              <g transform="translate(152 260)">
+                <ellipse cx="0" cy="42" rx="42" ry="54" fill="#fff8d8" />
+                <circle cx="0" cy="-2" r="34" fill="#fffdf4" />
+                <path d="M-10-9h20l-10 14z" fill="#ffb900" />
+                <circle cx="-11" cy="-11" r="4" fill="#15140f" />
+                <circle cx="11" cy="-11" r="4" fill="#15140f" />
+              </g>
+              <g transform="translate(382 244)">
+                <ellipse cx="0" cy="50" rx="50" ry="62" fill="#fff8d8" />
+                <circle cx="0" cy="-2" r="38" fill="#fffdf4" />
+                <path d="M-12-8h24L0 8z" fill="#ffb900" />
+                <circle cx="-12" cy="-12" r="4" fill="#15140f" />
+                <circle cx="12" cy="-12" r="4" fill="#15140f" />
+              </g>
+              <g transform="translate(600 264)">
+                <ellipse cx="0" cy="40" rx="39" ry="52" fill="#fff8d8" />
+                <circle cx="0" cy="-3" r="32" fill="#fffdf4" />
+                <path d="M-10-9h20L0 5z" fill="#ffb900" />
+                <circle cx="-10" cy="-12" r="4" fill="#15140f" />
+                <circle cx="10" cy="-12" r="4" fill="#15140f" />
+              </g>
+            </g>
+            <g fill="#ffd42a">
+              <ellipse cx="230" cy="378" rx="18" ry="24" />
+              <ellipse cx="486" cy="386" rx="18" ry="24" />
+              <ellipse cx="638" cy="384" rx="18" ry="24" />
+            </g>
+          </svg>
+        </figure>
+      </section>
+
+      <section class="egg-game-band" aria-labelledby="egg-game-title">
+        <div>
+          <p class="eyebrow">Discovery Game</p>
+          <h2 id="egg-game-title">Find the hidden production bonus.</h2>
+          <p>
+            Click the golden production markers. When the counter fills, the
+            contributor floor unlocks a note from operations.
+          </p>
+        </div>
+        <div class="egg-board" aria-live="polite">
+          <button class="egg-button" type="button" data-egg="alpha">Collect</button>
+          <button class="egg-button" type="button" data-egg="bravo">Collect</button>
+          <button class="egg-button" type="button" data-egg="charlie">Collect</button>
+          <p id="game-status">0 of 3 markers found.</p>
+        </div>
+      </section>
+
+      <section class="contributors-band" aria-labelledby="roster-title">
+        <div class="roster-heading">
+          <p class="eyebrow">Public PR Authors</p>
+          <h2 id="roster-title">Contributor roster</h2>
+          <p id="roster-summary">Loading contributors.</p>
+        </div>
+        <div id="contributors-grid" class="contributors-grid" aria-live="polite"></div>
+      </section>
+
+      <section class="production-ledger" aria-labelledby="ledger-title">
+        <div>
+          <p class="eyebrow">Operations Ledger</p>
+          <h2 id="ledger-title">The count protocol</h2>
+          <p>
+            The floor stamp below is generated from the live roster size so the
+            page can be checked without hand-counting static filler.
+          </p>
+        </div>
+        <div id="ledger-output" class="ledger-output" aria-label="production count ledger"></div>
+      </section>
+    </main>
+
+    <footer class="contributors-footer">
+      <div>
+        <span>AgentPipe C-Suite</span>
+        <address>
+          CEO: ceo@agentpipe.example<br />
+          CFO: finance@agentpipe.example<br />
+          COO: operations@agentpipe.example
+        </address>
+      </div>
+      <figure class="wave-video" aria-labelledby="wave-title">
+        <figcaption id="wave-title">Executive wave loop</figcaption>
+        <div class="video-frame" role="img" aria-label="Animated executive wave loop">
+          <span></span>
+          <span></span>
+          <span></span>
+        </div>
+      </figure>
+    </footer>
+
+    <script src="contributors.js"></script>
+  </body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,6 +20,7 @@
       <nav aria-label="Site sections">
         <a href="#engine">Engine</a>
         <a href="#banana">4D Banana</a>
+        <a href="contributors/">Contributors</a>
         <a href="#download">Download</a>
       </nav>
     </header>


### PR DESCRIPTION
﻿## Summary

Refs dwebagents/AgentPipe#1580.

Adds a scoped static `/contributors/` route under the existing GitHub Pages `docs/` site.

Included:

- `/contributors/` page with a factory-floor hero illustration
- generated roster for 37 public non-bot PR authors from the repository pull-request history
- profile links, PR counts, latest public PR titles, birthplace/essence facts, and stylized portraits for each contributor
- golden production marker discovery game
- generated production ledger that renders 71 visible `71` stamps from the current roster size
- C-suite contact footer with an animated wave loop
- navigation link from the home page

## Validation

- `contributors-data.json` parses successfully
- contributor count: 37
- production stamp formula: `37 * 2 - 3 = 71`
- local HTTP smoke test returned 200 for:
  - `/contributors/`
  - `/contributors/contributors.css`
  - `/contributors/contributors.js`
  - `/contributors/contributors-data.json`
- `git diff --cached --check` passed before commit

## Payout route if accepted

- Rail: USDC on Arbitrum One
- Address: `[REDACTED - provide privately after acceptance]`
