### PR TITLE
Yes chef. Right away chef. Add Butter Mode

### DIFF
--- a/docs/butter.html
+++ b/docs/butter.html
@@ -1,0 +1,238 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="AgentPipe Butter Mode turns task pipelines into a smooth, spreadable throughput ritual."
+    />
+    <title>AgentPipe Butter Mode</title>
+    <link rel="stylesheet" href="styles.css" />
+    <style>
+      :root {
+        --butter: #ffe680;
+        --butter-deep: #d79f11;
+        --toast: #6b3f17;
+        --cream: #fff7d1;
+      }
+
+      body {
+        background:
+          radial-gradient(circle at 20% 12%, rgba(255, 230, 128, 0.85), transparent 22rem),
+          radial-gradient(circle at 85% 18%, rgba(215, 159, 17, 0.35), transparent 18rem),
+          var(--cream);
+      }
+
+      .butter-shell {
+        padding: clamp(2rem, 5vw, 5rem);
+      }
+
+      .butter-hero,
+      .butter-card,
+      .butter-control-panel {
+        border: 1px solid rgba(107, 63, 23, 0.18);
+        border-radius: 24px;
+        background: rgba(255, 255, 255, 0.76);
+        box-shadow: 0 24px 70px rgba(107, 63, 23, 0.16);
+      }
+
+      .butter-hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(280px, 0.45fr);
+        gap: 2rem;
+        align-items: center;
+        padding: clamp(2rem, 5vw, 4rem);
+      }
+
+      .butter-hero h1 {
+        margin: 0;
+        font-size: clamp(3.5rem, 9vw, 8rem);
+        line-height: 0.86;
+      }
+
+      .butter-hero p {
+        max-width: 48rem;
+        color: #5f4a20;
+        font-size: clamp(1.05rem, 2vw, 1.4rem);
+      }
+
+      .butter-orb {
+        min-height: 18rem;
+        display: grid;
+        place-items: center;
+        border-radius: 22px;
+        background:
+          radial-gradient(circle at 42% 35%, #fff8bb 0 18%, transparent 19%),
+          radial-gradient(circle at 50% 50%, var(--butter) 0 40%, var(--butter-deep) 72%);
+        color: var(--toast);
+        font-size: clamp(5rem, 13vw, 9rem);
+        animation: wobble 4s ease-in-out infinite;
+      }
+
+      @keyframes wobble {
+        0%, 100% { transform: rotate(-3deg) scale(1); }
+        50% { transform: rotate(3deg) scale(1.035); }
+      }
+
+      .butter-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 1rem;
+        margin-top: 1.25rem;
+      }
+
+      .butter-card,
+      .butter-control-panel {
+        padding: 1.25rem;
+      }
+
+      .butter-card strong {
+        display: block;
+        color: var(--toast);
+        font-size: 1.4rem;
+      }
+
+      .butter-meter {
+        height: 1rem;
+        overflow: hidden;
+        border: 1px solid rgba(107, 63, 23, 0.24);
+        border-radius: 999px;
+        background: #fffdf1;
+      }
+
+      #butter-spread {
+        width: 71%;
+        height: 100%;
+        border-radius: inherit;
+        background: linear-gradient(90deg, var(--butter), var(--butter-deep));
+        transition: width 240ms ease;
+      }
+
+      .butter-control-panel {
+        margin-top: 1.25rem;
+      }
+
+      .butter-controls {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        align-items: end;
+      }
+
+      label {
+        display: grid;
+        gap: 0.35rem;
+        font-weight: 850;
+      }
+
+      input,
+      select,
+      button {
+        min-height: 2.75rem;
+        border: 1px solid rgba(107, 63, 23, 0.22);
+        border-radius: 12px;
+        padding: 0.65rem 0.8rem;
+        font: inherit;
+      }
+
+      button {
+        cursor: pointer;
+        background: var(--butter);
+        color: var(--toast);
+        font-weight: 950;
+      }
+
+      .butter-log {
+        min-height: 6rem;
+        margin-top: 1rem;
+        padding: 1rem;
+        border-radius: 14px;
+        background: #2d1e0f;
+        color: #ffe680;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      }
+
+      @media (max-width: 850px) {
+        .butter-hero,
+        .butter-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header" aria-label="Primary navigation">
+      <a class="brand" href="./" aria-label="AgentPipe home">
+        <img src="../logo.svg" alt="" />
+        <span>AgentPipe</span>
+      </a>
+      <nav aria-label="Site sections">
+        <a href="./">Home</a>
+        <a href="butter.html">Butter</a>
+        <a href="#controls">Controls</a>
+      </nav>
+    </header>
+
+    <main id="main" class="butter-shell">
+      <section class="butter-hero" aria-labelledby="butter-title">
+        <div>
+          <p><strong>Issue #1878: butter</strong></p>
+          <h1 id="butter-title">Butter Mode</h1>
+          <p>
+            AgentPipe now has a dedicated butter ritual: spread, churn, melt, and clarify
+            task throughput until the pipeline glides like warm toast.
+          </p>
+        </div>
+        <div class="butter-orb" aria-label="Animated butter mascot">🧈</div>
+      </section>
+
+      <section class="butter-grid" aria-label="Butter mode facts">
+        <article class="butter-card">
+          <strong>71%</strong>
+          <span>default spread coverage for compliant toast surfaces.</span>
+        </article>
+        <article class="butter-card">
+          <strong>0 crumbs</strong>
+          <span>no needless runtime dependencies; this is static and shelf-stable.</span>
+        </article>
+        <article class="butter-card">
+          <strong>4 states</strong>
+          <span>spread, churn, melt, and clarify — the complete butter lifecycle.</span>
+        </article>
+      </section>
+
+      <section class="butter-control-panel" id="controls" aria-labelledby="control-title">
+        <h2 id="control-title">Butter controls</h2>
+        <div class="butter-controls">
+          <label>Spread percentage
+            <input id="spread-input" type="range" min="0" max="100" value="71" />
+          </label>
+          <label>Butter state
+            <select id="butter-state">
+              <option value="spread">spread</option>
+              <option value="churn">churn</option>
+              <option value="melt">melt</option>
+              <option value="clarify">clarify</option>
+            </select>
+          </label>
+          <button id="butter-button" type="button">Apply butter</button>
+        </div>
+        <div class="butter-meter" aria-label="Butter spread meter">
+          <div id="butter-spread"></div>
+        </div>
+        <div id="butter-log" class="butter-log" aria-live="polite">
+          butter&gt; spread initialized at 71%
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <span>AgentPipe Butter Mode</span>
+      <span>Smooth task execution, salted to taste.</span>
+    </footer>
+
+    <script src="butter.js"></script>
+  </body>
+</html>

--- a/docs/butter.js
+++ b/docs/butter.js
@@ -1,0 +1,40 @@
+(() => {
+  const spreadInput = document.getElementById("spread-input");
+  const stateSelect = document.getElementById("butter-state");
+  const butterButton = document.getElementById("butter-button");
+  const spread = document.getElementById("butter-spread");
+  const log = document.getElementById("butter-log");
+
+  if (!spreadInput || !stateSelect || !butterButton || !spread || !log) {
+    return;
+  }
+
+  const butterCopy = {
+    spread: "spread applied: pipelines glide across warm operational toast",
+    churn: "churn complete: task lanes emulsified into cooperative momentum",
+    melt: "melt engaged: blockers softened into actionable droplets",
+    clarify: "clarify complete: noisy solids removed from the execution path",
+  };
+
+  function renderButter() {
+    const coverage = Number(spreadInput.value);
+    const state = stateSelect.value;
+    spread.style.width = `${coverage}%`;
+    spread.dataset.coverage = String(coverage);
+    log.textContent = `butter> ${butterCopy[state]} at ${coverage}% coverage`;
+  }
+
+  spreadInput.addEventListener("input", renderButter);
+  stateSelect.addEventListener("change", renderButter);
+  butterButton.addEventListener("click", renderButter);
+
+  renderButter();
+
+  window.AgentPipeButter = {
+    butterCopy,
+    renderButter,
+    get coverage() {
+      return Number(spread.dataset.coverage || 0);
+    },
+  };
+})();

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,6 +20,7 @@
       <nav aria-label="Site sections">
         <a href="#engine">Engine</a>
         <a href="#banana">4D Banana</a>
+        <a href="butter.html">Butter</a>
         <a href="#download">Download</a>
       </nav>
     </header>

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "test:butter": "node tests/butter-page.test.mjs"
+  },
   "dependencies": {
     "@11ty/eleventy": "^3.1.6"
   }

--- a/tests/butter-page.test.mjs
+++ b/tests/butter-page.test.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const html = readFileSync(join(root, 'docs', 'butter.html'), 'utf8');
+const js = readFileSync(join(root, 'docs', 'butter.js'), 'utf8');
+const index = readFileSync(join(root, 'docs', 'index.html'), 'utf8');
+
+assert.match(html, /<title>AgentPipe Butter Mode<\/title>/, 'butter page should have a specific title');
+assert.match(html, /Issue #1878: butter/, 'butter page should reference the bounty issue');
+assert.match(html, /id="spread-input"/, 'butter page should expose a spread range control');
+assert.match(html, /id="butter-state"/, 'butter page should expose state selection');
+assert.match(html, /id="butter-button"/, 'butter page should expose an apply button');
+assert.match(html, /id="butter-spread"/, 'butter page should expose a visual meter');
+assert.match(html, /id="butter-log"/, 'butter page should expose live output');
+assert.match(html, /butter\.js/, 'butter page should load its script');
+assert.match(html, /spread|churn|melt|clarify/, 'butter page should include the butter lifecycle states');
+assert.match(index, /href="butter\.html"/, 'home nav should link to butter page');
+
+for (const state of ['spread', 'churn', 'melt', 'clarify']) {
+  assert.match(js, new RegExp(`${state}:`), `butter JS should define copy for ${state}`);
+}
+assert.match(js, /window\.AgentPipeButter/, 'butter JS should expose a small smoke-test API');
+assert.match(js, /dataset\.coverage/, 'butter JS should store rendered coverage for smoke testing');
+
+console.log('butter-page checks passed');


### PR DESCRIPTION
Yes chef. Right away chef.

Fixes #1878.

## Summary
- Adds a new static `docs/butter.html` page for the butter bounty.
- Implements a self-contained Butter Mode experience with an animated butter mascot, 71% default spread meter, lifecycle states (`spread`, `churn`, `melt`, `clarify`), and interactive controls.
- Links the butter page from the docs home navigation.
- Adds `npm run test:butter` with static acceptance checks for the page, script, navigation link, and smoke-test API.

## Verification
- `npm run test:butter`
- `node --check docs/butter.js`
- `git diff --check`
- Manual browser smoke test at `http://127.0.0.1:8127/butter.html`: verified the page renders, `window.AgentPipeButter` exists, changing coverage to `88` and state to `clarify` updates the live log, and no console errors were reported.
