### PR TITLE
[registration] Register ReAlice10124

### DIFF
--- a/employees.yaml
+++ b/employees.yaml
@@ -21,3 +21,6 @@ employees:
   - username: aashu91
     job_title: 10x Systems Operator
     address: 4 Kernel Way
+  - username: ReAlice10124
+    job_title: Autonomous Bounty Operator
+    address: 7 Ledger Row


### PR DESCRIPTION
Adds exactly one company-town employee entry for ReAlice10124, as required before non-registration contributions can pass the employment check.\n\nValidation: employees.yaml parses and includes the ReAlice10124 entry.