### PR TITLE
feat: add contributors page (fixes #1580)

### DIFF
--- a/contributors/index.html
+++ b/contributors/index.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Contributors - AgentPipe</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#1a1a2e;color:#eee}
+.hero{position:relative;min-height:50vh;display:flex;align-items:center;justify-content:center;text-align:center;padding:2rem;background:linear-gradient(135deg,#1a1a2e,#16213e,#0f3460);overflow:hidden}
+.hero::before{content:"";position:absolute;inset:0;background:radial-gradient(ellipse at 30% 50%,rgba(255,200,50,0.08) 0%,transparent 60%),radial-gradient(ellipse at 70% 50%,rgba(255,100,50,0.05) 0%,transparent 60%);animation:drift 20s ease-in-out infinite}
+@keyframes drift{0%,100%{transform:translateY(0)}50%{transform:translateY(-20px)}}
+.hero-content{position:relative;z-index:1;max-width:800px}
+.hero h1{font-size:3rem;margin-bottom:.5rem;background:linear-gradient(135deg,#f7971e,#ffd200);-webkit-background-clip:text;-webkit-text-fill-color:transparent}
+.hero p{font-size:1.2rem;color:#aaa}
+.goose{width:120px;height:120px;margin:0 auto 1rem;opacity:.8}
+.cont{max-width:1000px;margin:0 auto;padding:2rem}
+.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:1rem}
+.card{display:flex;align-items:center;gap:1rem;padding:1rem;border-radius:12px;background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.1);transition:transform .2s}
+.card:hover{transform:translateY(-2px);box-shadow:0 4px 20px rgba(0,0,0,0.3)}
+.avatar{width:60px;height:60px;border-radius:50%;border:2px solid rgba(255,200,50,0.3)}
+.info{flex:1;min-width:0}
+.uname{font-weight:600;color:#ffd200;text-decoration:none;font-size:1.1rem}
+.uname:hover{text-decoration:underline}
+.badges{display:flex;flex-wrap:wrap;gap:.3rem;margin-top:.4rem}
+.badge{font-size:.75rem;padding:.15rem .5rem;border-radius:20px}
+.gold{background:rgba(255,215,0,0.2);color:#ffd700}
+.silver{background:rgba(192,192,192,0.2);color:#c0c0c0}
+.bronze{background:rgba(205,127,50,0.2);color:#cd7f32}
+.count{background:rgba(100,200,255,0.15);color:#64c8ff}
+.excluded{margin-top:2rem;padding:1rem;background:rgba(255,0,0,0.05);border-radius:12px;font-size:.85rem;color:#888;text-align:center}
+</style>
+</head>
+<body>
+<section class="hero">
+<div class="hero-content">
+<svg class="goose" viewBox="0 0 200 200">
+<ellipse cx="100" cy="120" rx="60" ry="40" fill="#f0f0f0"/>
+<ellipse cx="100" cy="75" rx="30" ry="25" fill="#e8e8e8"/>
+<ellipse cx="100" cy="70" rx="8" ry="12" fill="#ff8c00"/>
+<circle cx="90" cy="65" r="3" fill="#333"/><circle cx="110" cy="65" r="3" fill="#333"/>
+<path d="M95 75 Q100 80 105 75" stroke="#333" stroke-width="1.5" fill="none"/>
+<rect x="60" y="150" rx="5" width="80" height="30" fill="#ffd700" opacity=".5"/>
+<circle cx="40" cy="130" r="15" fill="#e8e8e8" opacity=".4"/>
+<circle cx="160" cy="130" r="15" fill="#e8e8e8" opacity=".4"/>
+</svg>
+<h1>AgentPipe Contributors</h1>
+<p>The hard-working geese who keep the factory running</p>
+<p style="font-size:.9rem;color:#777">20 honored workers</p>
+</div>
+</section>
+<div class="cont"><div class="grid">
+    <div class="card">
+      <img src="https://avatars.githubusercontent.com/sneakers-the-rat?s=80" alt="" class="avatar" loading="lazy">
+      <div class="info">
+        <a href="https://github.com/sneakers-the-rat" class="uname">@sneakers-the-rat</a>
+        <div class="badges"><span class="badge gold">Gold</span><span class="badge count">145 commits</span></div>
+      </div>
+    </div>
+    <div class="card">
+      <img src="https://avatars.githubusercontent.com/ricci?s=80" alt="" class="avatar" loading="lazy">
+      <div class="info">
+        <a href="https://github.com/ricci" class="uname">@ricci</a>
+        <div class="badges"><span class="badge bronze">Bronze</span><span class="badge count">10 commits</span></div>
+      </div>
+    </div>
+    <div class="card">
+      <img src="https://avatars.githubusercontent.com/therealsaitama0?s=80" alt="" class="avatar" loading="lazy">
+      <div class="info">
+        <a href="https://github.com/therealsaitama0" class="uname">@therealsaitama0</a>
+        <div class="badges"><span class="badge count">5 commits</span></div>
+      </div>
+    </div>
+    <div class="card">
+      <img src="https://avatars.githubusercontent.com/hobgoblina?s=80" alt="" class="avatar" loading="lazy">
+      <div class="info">
+        <a href="https://github.com/hobgoblina" class="uname">@hobgoblina</a>
+        <div class="badges"><span class="badge count">5 commits</span></div>
+      </div>
+    </div>
+    <div class="card">
+      <img src="https://avatars.githubusercontent.com/CleanDev-Fix?s=80" alt="" class="avatar" loading="lazy">
+      <div class="info">
+        <a href="https://github.com/CleanDev-Fix" class="uname">@CleanDev-Fix</a>
+        <div class="badges"><span class="badge count">5 commits</span></div>
+      </div>
+    </div>
+    <div class="card">
+      <img src="https://avatars.githubusercontent.com/astatide?s=80" alt="" class="avatar" loading="lazy">
+      <div class="info">
+        <a href="https://github.com/astatide" class="uname">@astatide</a>
+        <div class="badges"><span class="badge count">5 commits</span></div>
+      </div>
+    </div>
+    <div class="card">
+      <img src="https://avatars.githubusercontent.com/drewcassidy?s=80" alt="" class="avatar" loading="lazy">
+      <div class="info">
+        <a href="https://github.com/drewcassidy" class="uname">@drewcassidy</a>
+        <div class="badges"><span class="badge count">4 commits</span></div>
+      </div>
+    </div>
+    <div class="card">
+      <img src="https://avatars.githubusercontent.com/i-sayankh?s=80" alt="" class="avatar" loading="lazy">
+      <div class="info">
+        <a href="https://github.com/i-sayankh" class="uname">@i-sayankh</a>
+        <div class="badges"><span class="badge count">4 commits</span></div>
+      </div>
+    </div>
+    <div class="card">
+      <img src="https://avatars.githubusercontent.com/Votienduong2208?s=80" alt="" class="avatar" loading="lazy">
+      <div class="info">
+        <a href="https://github.com/Votienduong2208" class="uname">@Votienduong2208</a>
+        <div class="badges"><span class="badge count">2 commits</span></div>
+      </div>
+    </div>
+    <div class="card">
+      <img src="https://avatars.githubusercontent.com/zero-logic0316?s=80" alt="" class="avatar" loading="lazy">
+      <div class="info">
+        <a href="https://github.com/zero-logic0316" class="uname">@zero-logic0316</a>
+        <div class="badges"><span class="badge count">1 commits</span></div>
+      </div>
+    </div>
+    <div class="card">
+      <img src="https://avatars.githubusercontent.com/ldbld?s=80" alt="" class="avatar" loading="lazy">
+      <div class="info">
+        <a href="https://github.com/ldbld" class="uname">@ldbld</a>
+        <div class="badges"><span class="badge count">1 commits</span></div>
+      </div>
+    </div>
+    <div class="card">
+      <img src="https://avatars.githubusercontent.com/johnanleitner1-Coder?s=80" alt="" class="avatar" loading="lazy">
+      <div class="info">
+        <a href="https://github.com/johnanleitner1-Coder" class="uname">@johnanleitner1-Coder</a>
+        <div class="badges"><span class="badge count">1 commits</span></div>
+      </div>
+    </div>
+    <div class="card">
+      <img src="https://avatars.githubusercontent.com/TobiLabu?s=80" alt="" class="avatar" loading="lazy">
+      <div class="info">
+        <a href="https://github.com/TobiLabu" class="uname">@TobiLabu</a>
+        <div class="badges"><span class="badge count">1 commits</span></div>
+      </div>
+    </div>
+    <div class="card">
+      <img src="https://avatars.githubusercontent.com/sgrigson?s=80" alt="" class="avatar" loading="lazy">
+      <div class="info">
+        <a href="https://github.com/sgrigson" class="uname">@sgrigson</a>
+        <div class="badges"><span class="badge count">1 commits</span></div>
+      </div>
+    </div>
+    <div class="card">
+      <img src="https://avatars.githubusercontent.com/SKYJAMES777?s=80" alt="" class="avatar" loading="lazy">
+      <div class="info">
+        <a href="https://github.com/SKYJAMES777" class="uname">@SKYJAMES777</a>
+        <div class="badges"><span class="badge count">1 commits</span></div>
+      </div>
+    </div>
+    <div class="card">
+      <img src="https://avatars.githubusercontent.com/rseeber?s=80" alt="" class="avatar" loading="lazy">
+      <div class="info">
+        <a href="https://github.com/rseeber" class="uname">@rseeber</a>
+        <div class="badges"><span class="badge count">1 commits</span></div>
+      </div>
+    </div>
+    <div class="card">
+      <img src="https://avatars.githubusercontent.com/ReAlice10124?s=80" alt="" class="avatar" loading="lazy">
+      <div class="info">
+        <a href="https://github.com/ReAlice10124" class="uname">@ReAlice10124</a>
+        <div class="badges"><span class="badge count">1 commits</span></div>
+      </div>
+    </div>
+    <div class="card">
+      <img src="https://avatars.githubusercontent.com/arrjay?s=80" alt="" class="avatar" loading="lazy">
+      <div class="info">
+        <a href="https://github.com/arrjay" class="uname">@arrjay</a>
+        <div class="badges"><span class="badge count">1 commits</span></div>
+      </div>
+    </div>
+    <div class="card">
+      <img src="https://avatars.githubusercontent.com/Be-ing?s=80" alt="" class="avatar" loading="lazy">
+      <div class="info">
+        <a href="https://github.com/Be-ing" class="uname">@Be-ing</a>
+        <div class="badges"><span class="badge count">1 commits</span></div>
+      </div>
+    </div>
+    <div class="card">
+      <img src="https://avatars.githubusercontent.com/rhoggs-bot-test-account?s=80" alt="" class="avatar" loading="lazy">
+      <div class="info">
+        <a href="https://github.com/rhoggs-bot-test-account" class="uname">@rhoggs-bot-test-account</a>
+        <div class="badges"><span class="badge count">1 commits</span></div>
+      </div>
+    </div></div>
+<div class="excluded">C-Suite (agentpipe-bot, aashu91) and bots excluded per policy.</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Closes #1580

## What is included
- /contributors/index.html with goose-themed hero and contributor grid
- 20+ contributors with avatars, commit counts, achievement badges
- C-suite and bots excluded per policy

/opire try