### PR TITLE
Fixes #1580: Create contributors webpage

### DIFF
--- a/src/frontend/src/contributors.html
+++ b/src/frontend/src/contributors.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Contributors | AgentPipe</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 2rem;
+            background-color: #f9f9f9;
+        }
+        h1 {
+            text-align: center;
+            color: #2c3e50;
+            margin-bottom: 2rem;
+        }
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+            gap: 1.5rem;
+        }
+        .card {
+            background: white;
+            border-radius: 8px;
+            padding: 1.5rem;
+            text-align: center;
+            box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+            transition: transform 0.2s;
+        }
+        .card:hover {
+            transform: translateY(-5px);
+        }
+        img {
+            border-radius: 50%;
+            width: 100px;
+            height: 100px;
+            margin-bottom: 1rem;
+        }
+        a {
+            text-decoration: none;
+            color: #3498db;
+            font-weight: bold;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+        .commits {
+            font-size: 0.9rem;
+            color: #7f8c8d;
+            margin-top: 0.5rem;
+        }
+        #loading {
+            text-align: center;
+            font-style: italic;
+            color: #666;
+        }
+    </style>
+</head>
+<body>
+
+    <h1>AgentPipe Contributors</h1>
+    <div id="loading">Loading contributors from GitHub...</div>
+    <div class="grid" id="contributors-container"></div>
+
+    <script>
+        async function fetchContributors() {
+            const container = document.getElementById('contributors-container');
+            const loading = document.getElementById('loading');
+            
+            try {
+                // Fetch contributors for dwebagents/AgentPipe
+                const response = await fetch('https://api.github.com/repos/dwebagents/AgentPipe/contributors');
+                if (!response.ok) throw new Error('Failed to fetch data');
+                
+                const contributors = await response.json();
+                loading.style.display = 'none';
+
+                contributors.forEach(user => {
+                    const card = document.createElement('div');
+                    card.className = 'card';
+                    card.innerHTML = `
+                        <a href="${user.html_url}" target="_blank" rel="noopener noreferrer">
+                            <img src="${user.avatar_url}" alt="${user.login}">
+                            <div>@${user.login}</div>
+                        </a>
+                        <div class="commits">${user.contributions} contributions</div>
+                    `;
+                    container.appendChild(card);
+                });
+            } catch (error) {
+                loading.textContent = 'Error loading contributors. Please try again later.';
+                console.error(error);
+            }
+        }
+
+        fetchContributors();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Yes chef. Right away chef.

Closes #1580.
Created a responsive `contributors.html` page that dynamically fetches and displays repository contributors using the GitHub API. 

Payout address (USDC on Base): 0xCB8002375Bd0fd275d9052EfFfBa3593D4dFCc20